### PR TITLE
revert withdraw_nft_l1 script

### DIFF
--- a/contrib/scripts/nft-use-case/withdraw_nft_l1.js
+++ b/contrib/scripts/nft-use-case/withdraw_nft_l1.js
@@ -11,6 +11,7 @@ import {
 import { StacksTestnet, HIRO_MOCKNET_DEFAULT } from '@stacks/network';
 
 
+// NOTE: The arguments to the `withdraw-nft-asset` function change with Stacks 2.1
 async function main() {
     const network = new StacksTestnet({url: HIRO_MOCKNET_DEFAULT});
     const hyperchainUrl = process.env.HYPERCHAIN_URL;

--- a/contrib/scripts/nft-use-case/withdraw_nft_l1.js
+++ b/contrib/scripts/nft-use-case/withdraw_nft_l1.js
@@ -39,8 +39,6 @@ async function main() {
         functionArgs: [
             uintCV(5), // ID
             standardPrincipalCV(addr), // recipient
-            uintCV(withdrawalId), // withdrawal-id
-            uintCV(withdrawalBlockHeight), // withdrawal-height
             contractPrincipalCV(contractAddr, 'simple-nft-l1'), // nft-contract
             contractPrincipalCV(contractAddr, 'simple-nft-l1'), // nft-mint-contract
             cv_merkle_entry.withdrawal_root, // withdrawal root


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/blockstack/stacks-blockchain/blob/master/sip/sip-000-stacks-improvement-proposal-process.md.
-->

### Description
The NFT use case temporarily broke, since PR #142 updated the `withdraw_nft_l1.js` script to correspond with the updated hyperchains contract. However, clarinet currently uses a different version of the hyperchains contract, which led to issues. 

Deploying the new version of the hyperchains contract on the testnet is currently impossible, since the new version uses a Clarity2 function. Thus, we are leaving the old version of the hyperchains contract as the default one launched by Clarinet, and reverting the change in the `withdraw_nft_l1.js` script.
