### PR TITLE
Removes the unused function is-principal-eq.

### DIFF
--- a/core-contracts/contracts/subnet.clar
+++ b/core-contracts/contracts/subnet.clar
@@ -102,14 +102,6 @@
     )
 )
 
-;; Helper function for fold: if a == b, return none; else return b
-;; Returns (optional principal)
-(define-private (is-principal-eq (miner-a principal) (search-for (optional principal)))
-    (if (is-eq (some miner-a) search-for)
-        none
-        search-for
-    )
-)
 ;; Helper function: returns a boolean indicating whether the given principal is a miner
 ;; Returns bool
 (define-private (is-miner (miner-to-check principal))


### PR DESCRIPTION
This function is not used anywhere and has similar functionality (but a different return type) as is-miner.