### PR TITLE
Add burnchain op type to the `new_block` event

### DIFF
--- a/src/chainstate/burn/operations/mod.rs
+++ b/src/chainstate/burn/operations/mod.rs
@@ -353,7 +353,7 @@ pub struct UserBurnSupportOp {
     pub burn_header_hash: BurnchainHeaderHash, // hash of burnchain block with this tx
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum BlockstackOperationType {
     LeaderBlockCommit(LeaderBlockCommitOp),
     DepositStx(DepositStxOp),

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -4513,10 +4513,9 @@ impl StacksChainState {
         Ok((applied, receipts))
     }
 
-
-    /// NOTE: stacking ops are currently not processed by subnets nodes; thus, no 
-    /// StackStx op receipts are added to the return. If anyone wants to again 
-    /// process stacking ops, the receipt generation logic must be uncommented. 
+    /// NOTE: stacking ops are currently not processed by subnets nodes; thus, no
+    /// StackStx op receipts are added to the return. If anyone wants to again
+    /// process stacking ops, the receipt generation logic must be uncommented.
     ///
     /// Process any Stacking-related bitcoin operations
     ///  that haven't been processed in this Stacks fork yet.
@@ -4598,9 +4597,9 @@ impl StacksChainState {
         all_receipts
     }
 
-    /// NOTE: transfer stx ops are currently not processed by subnets nodes; thus, no 
-    /// TransferStx op receipts are added to the return. If anyone wants to again 
-    /// process transfer stx ops, the receipt generation logic must be uncommented. 
+    /// NOTE: transfer stx ops are currently not processed by subnets nodes; thus, no
+    /// TransferStx op receipts are added to the return. If anyone wants to again
+    /// process transfer stx ops, the receipt generation logic must be uncommented.
     ///
     /// Process any STX transfer bitcoin operations
     ///  that haven't been processed in this Stacks fork yet.
@@ -4684,7 +4683,9 @@ impl StacksChainState {
                         clarity_tx.increment_ustx_liquid_supply(*amount);
 
                         Some(StacksTransactionReceipt {
-                            transaction: TransactionOrigin::Burn(BlockstackOperationType::DepositStx(deposit_stx_op)),
+                            transaction: TransactionOrigin::Burn(
+                                BlockstackOperationType::DepositStx(deposit_stx_op),
+                            ),
                             events: vec![result],
                             result: Value::okay_true(),
                             post_condition_aborted: false,
@@ -4738,7 +4739,9 @@ impl StacksChainState {
 
                 match result {
                     Ok((value, _, events)) => Some(StacksTransactionReceipt {
-                        transaction: TransactionOrigin::Burn(BlockstackOperationType::DepositFt(deposit_ft_op)),
+                        transaction: TransactionOrigin::Burn(BlockstackOperationType::DepositFt(
+                            deposit_ft_op,
+                        )),
                         events,
                         result: value,
                         post_condition_aborted: false,
@@ -4796,7 +4799,9 @@ impl StacksChainState {
 
                 match result {
                     Ok((value, _, events)) => Some(StacksTransactionReceipt {
-                        transaction: TransactionOrigin::Burn(BlockstackOperationType::DepositNft(deposit_nft_op)),
+                        transaction: TransactionOrigin::Burn(BlockstackOperationType::DepositNft(
+                            deposit_nft_op,
+                        )),
                         events,
                         result: value,
                         post_condition_aborted: false,

--- a/src/chainstate/stacks/events.rs
+++ b/src/chainstate/stacks/events.rs
@@ -1,4 +1,5 @@
 use crate::burnchains::Txid;
+use crate::chainstate::burn::operations::BlockstackOperationType;
 use crate::chainstate::stacks::StacksMicroblockHeader;
 use crate::chainstate::stacks::StacksTransaction;
 use crate::codec::StacksMessageCodec;
@@ -14,7 +15,7 @@ pub use clarity::vm::events::StacksTransactionEvent;
 #[derive(Debug, Clone, PartialEq)]
 pub enum TransactionOrigin {
     Stacks(StacksTransaction),
-    Burn(Txid),
+    Burn(BlockstackOperationType),
 }
 
 impl From<StacksTransaction> for TransactionOrigin {
@@ -26,13 +27,13 @@ impl From<StacksTransaction> for TransactionOrigin {
 impl TransactionOrigin {
     pub fn txid(&self) -> Txid {
         match self {
-            TransactionOrigin::Burn(txid) => txid.clone(),
+            TransactionOrigin::Burn(op) => op.txid(),
             TransactionOrigin::Stacks(tx) => tx.txid(),
         }
     }
     pub fn serialize_to_vec(&self) -> Vec<u8> {
         match self {
-            TransactionOrigin::Burn(txid) => txid.as_bytes().to_vec(),
+            TransactionOrigin::Burn(op) => op.txid().as_bytes().to_vec(),
             TransactionOrigin::Stacks(tx) => tx.txid().as_bytes().to_vec(),
         }
     }

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -198,7 +198,9 @@ impl EventObserver {
         };
 
         let (txid, raw_tx, burnchain_op) = match tx {
-            TransactionOrigin::Burn(op) => (op.txid().to_string(), "00".to_string(), json!(op.clone())),
+            TransactionOrigin::Burn(op) => {
+                (op.txid().to_string(), "00".to_string(), json!(op.clone()))
+            }
             TransactionOrigin::Stacks(ref tx) => {
                 let txid = tx.txid().to_string();
                 let bytes = tx.serialize_to_vec();

--- a/testnet/stacks-node/src/tests/l1_observer_test.rs
+++ b/testnet/stacks-node/src/tests/l1_observer_test.rs
@@ -260,8 +260,8 @@ fn select_transactions_where(
     return result;
 }
 
-/// Deserializes the `StacksTransaction` objects from `blocks` and returns all those that
-/// match `test_fn`.
+/// Deserializes the `BlockstackOperationType` objects (non-null objects are produced by burn 
+/// transactions) from `blocks` and returns all those that match `test_fn`.
 fn select_burn_transactions_where(
     blocks: &Vec<serde_json::Value>,
     test_fn: fn(&BlockstackOperationType) -> bool,

--- a/testnet/stacks-node/src/tests/l1_observer_test.rs
+++ b/testnet/stacks-node/src/tests/l1_observer_test.rs
@@ -260,7 +260,7 @@ fn select_transactions_where(
     return result;
 }
 
-/// Deserializes the `BlockstackOperationType` objects (non-null objects are produced by burn 
+/// Deserializes the `BlockstackOperationType` objects (non-null objects are produced by burn
 /// transactions) from `blocks` and returns all those that match `test_fn`.
 fn select_burn_transactions_where(
     blocks: &Vec<serde_json::Value>,

--- a/testnet/stacks-node/src/tests/l1_observer_test.rs
+++ b/testnet/stacks-node/src/tests/l1_observer_test.rs
@@ -275,7 +275,7 @@ fn select_burn_transactions_where(
                 serde_json::from_value(burnchain_op.clone()).unwrap();
             if let Some(op) = new_op {
                 println!(
-                    "select_transactions_where considers: block_idx: {}, tx_idx: {}, tx: {:?}, parsed: {:?}",
+                    "select_burn_transactions_where considers: block_idx: {}, tx_idx: {}, tx: {:?}, parsed: {:?}",
                     block_idx, tx_idx, &tx, &op
                 );
 

--- a/testnet/stacks-node/src/tests/l1_observer_test.rs
+++ b/testnet/stacks-node/src/tests/l1_observer_test.rs
@@ -271,7 +271,8 @@ fn select_burn_transactions_where(
         let transactions = block.get("transactions").unwrap().as_array().unwrap();
         for (tx_idx, tx) in transactions.iter().enumerate() {
             let burnchain_op = tx.get("burnchain_op").unwrap();
-            let new_op: Option<BlockstackOperationType> = serde_json::from_value(burnchain_op.clone()).unwrap();            
+            let new_op: Option<BlockstackOperationType> =
+                serde_json::from_value(burnchain_op.clone()).unwrap();
             if let Some(op) = new_op {
                 println!(
                     "select_transactions_where considers: block_idx: {}, tx_idx: {}, tx: {:?}, parsed: {:?}",
@@ -283,7 +284,6 @@ fn select_burn_transactions_where(
                     result.push(op);
                 }
             }
-            
         }
     }
 
@@ -794,17 +794,16 @@ fn l1_deposit_and_withdraw_asset_integration_test() {
     let amount = Value::deserialize(&result, &TypeSignature::UIntType);
     assert_eq!(amount, Value::UInt(1));
 
-     // Check the burnchain ops 
-     let block_data = test_observer::get_blocks(); 
-     let burn_deposit_ft_tx = select_burn_transactions_where(&block_data, |op| {
-         if let BlockstackOperationType::DepositFt(_) = op {
-             true
-         } else {
-             false
-         }
-     }); 
-     assert_eq!(burn_deposit_ft_tx.len(), 1);
- 
+    // Check the burnchain ops
+    let block_data = test_observer::get_blocks();
+    let burn_deposit_ft_tx = select_burn_transactions_where(&block_data, |op| {
+        if let BlockstackOperationType::DepositFt(_) = op {
+            true
+        } else {
+            false
+        }
+    });
+    assert_eq!(burn_deposit_ft_tx.len(), 1);
 
     // Check that the user owns the NFT on the hyperchain now
     let res = call_read_only(
@@ -831,15 +830,15 @@ fn l1_deposit_and_withdraw_asset_integration_test() {
         Value::some(Value::Principal(user_addr.into())).unwrap()
     );
 
-    // Check the burnchain ops 
-    let block_data = test_observer::get_blocks(); 
+    // Check the burnchain ops
+    let block_data = test_observer::get_blocks();
     let burn_deposit_nft_tx = select_burn_transactions_where(&block_data, |op| {
         if let BlockstackOperationType::DepositNft(_) = op {
             true
         } else {
             false
         }
-    }); 
+    });
     assert_eq!(burn_deposit_nft_tx.len(), 1);
 
     // Check that the user does not own the FT on the L1
@@ -1460,15 +1459,15 @@ fn l1_deposit_and_withdraw_stx_integration_test() {
         (l1_starting_account_balance - default_fee * l1_nonce - 1) as u128
     );
 
-    // Check the burnchain ops 
-    let block_data = test_observer::get_blocks(); 
+    // Check the burnchain ops
+    let block_data = test_observer::get_blocks();
     let burn_deposit_stx_tx = select_burn_transactions_where(&block_data, |op| {
         if let BlockstackOperationType::DepositStx(_) = op {
             true
         } else {
             false
         }
-    }); 
+    });
     assert_eq!(burn_deposit_stx_tx.len(), 1);
 
     // Call the withdraw stx function on the L2 from unauthorized user
@@ -2197,17 +2196,16 @@ fn nft_deposit_and_withdraw_integration_test() {
     );
     assert_eq!(owner, Value::okay(Value::none()).unwrap());
 
-    // Check the burnchain ops 
-    let block_data = test_observer::get_blocks(); 
+    // Check the burnchain ops
+    let block_data = test_observer::get_blocks();
     let burn_deposit_tx = select_burn_transactions_where(&block_data, |op| {
         if let BlockstackOperationType::DepositNft(_) = op {
             true
         } else {
             false
         }
-    }); 
+    });
     assert_eq!(burn_deposit_tx.len(), 1);
-
 
     // Withdraw the L1 native NFT from the L2 (with `nft-withdraw?`)
     let l2_withdraw_nft_tx = make_contract_call(


### PR DESCRIPTION
### Description
This PR adds greater information about burnchain operations (such as DepositNft, DepositStx, etc), to the `new_block` event emitted by the event observer. 

A new field is added for each tx json object, called `burnchain_op`, which contains information specific to the burn transaction. 

### Applicable issues
- fixes #155 and possibly #160 as well (will confirm with @rafaelcr ) 
