### PR TITLE
chore: Update clarinet version in `subnets`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: hirosystems/clarinet
-          ref: hack/2.1
+          ref: main
           submodules: recursive
       - name: Build Clarinet with 2.1
         run: cargo build -p=clarinet-cli

--- a/core-contracts/Clarinet.toml
+++ b/core-contracts/Clarinet.toml
@@ -26,6 +26,7 @@ path = "contracts/helper/simple-ft.clar"
 depends_on = ["trait-standards"]
 
 [contracts.hyperchains]
+clarity_version = 2
 path = "contracts/hyperchains.clar"
 depends_on = ["trait-standards"]
 

--- a/core-contracts/contracts/hyperchains.clar
+++ b/core-contracts/contracts/hyperchains.clar
@@ -491,7 +491,7 @@
 )
 
 (define-read-only (leaf-hash-withdraw-stx (amount uint) (recipient principal) (withdrawal-id uint) (height uint))
-    (sha512/256 (concat 0x00 (unwrap-panic (to-consensus-buff
+    (sha512/256 (concat 0x00 (unwrap-panic (to-consensus-buff?
         {
             type: "stx",
             amount: amount,
@@ -502,7 +502,7 @@
 )))))
 
 (define-read-only (leaf-hash-withdraw-nft (asset-contract principal) (nft-id uint) (recipient principal) (withdrawal-id uint) (height uint))
-    (sha512/256 (concat 0x00 (unwrap-panic (to-consensus-buff
+    (sha512/256 (concat 0x00 (unwrap-panic (to-consensus-buff?
         {
             type: "nft",
             nft-id: nft-id,
@@ -514,7 +514,7 @@
 )))))
 
 (define-read-only (leaf-hash-withdraw-ft (asset-contract principal) (amount uint) (recipient principal) (withdrawal-id uint) (height uint))
-    (sha512/256 (concat 0x00 (unwrap-panic (to-consensus-buff
+    (sha512/256 (concat 0x00 (unwrap-panic (to-consensus-buff?
         {
             type: "ft",
             amount: amount,


### PR DESCRIPTION
### Description

This PR updates `ci.yml` to point to `main` version of `clarinet`.

It changes the Stacks 2.1 function used in the hyperchains contract to be `to-consensus-buff?` instead of `to-consensus-buff`.