### PR TITLE
feat: Refactor `hyperchains.clar` to use optional traits

### DIFF
--- a/core-contracts/contracts/hyperchains.clar
+++ b/core-contracts/contracts/hyperchains.clar
@@ -302,22 +302,6 @@
     )
 )
 
-;; Like `withdraw-nft-asset` but without allowing or requiring a mint function. In order to withdraw, the user must
-;; have the appropriate balance.
-(define-public (withdraw-nft-asset-no-mint (id uint) (recipient principal) (withdrawal-id uint) (height uint) (nft-contract <nft-trait>) (withdrawal-root (buff 32)) (withdrawal-leaf-hash (buff 32)) (sibling-hashes (list 50 (tuple (hash (buff 32)) (is-left-side bool) ) )))
-    (begin
-        ;; Check that the asset belongs to the allowed-contracts map
-        (unwrap! (map-get? allowed-contracts (contract-of nft-contract)) (err ERR_DISALLOWED_ASSET))
-
-        (asserts! (try! (inner-withdraw-nft-asset id recipient withdrawal-id height nft-contract none withdrawal-root withdrawal-leaf-hash sibling-hashes)) (err ERR_TRANSFER_FAILED))
-
-        ;; Emit a print event
-        (print { event: "withdraw-nft", nft-id: id, l1-contract-id: nft-contract, recipient: recipient })
-
-        (ok true)
-    )
-)
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; FOR FUNGIBLE TOKEN ASSET TRANSFERS
 

--- a/core-contracts/contracts/hyperchains.clar
+++ b/core-contracts/contracts/hyperchains.clar
@@ -239,7 +239,7 @@
 
 ;; Helper function for `withdraw-nft-asset`
 ;; Returns response<bool, int>
-(define-public (inner-withdraw-nft-asset (id uint) (recipient principal) (withdrawal-id uint) (height uint) (nft-contract <nft-trait>) (nft-mint-contract <mint-from-hyperchain-trait>) (withdrawal-root (buff 32)) (withdrawal-leaf-hash (buff 32)) (sibling-hashes (list 50 (tuple (hash (buff 32)) (is-left-side bool) ) )))
+(define-public (inner-withdraw-nft-asset (id uint) (recipient principal) (withdrawal-id uint) (height uint) (nft-contract <nft-trait>) (nft-mint-contract (optional <mint-from-hyperchain-trait>)) (withdrawal-root (buff 32)) (withdrawal-leaf-hash (buff 32)) (sibling-hashes (list 50 (tuple (hash (buff 32)) (is-left-side bool) ) )))
     (let ((hashes-are-valid (check-withdrawal-hashes withdrawal-root withdrawal-leaf-hash sibling-hashes)))
 
         (asserts! (try! hashes-are-valid) (err ERR_VALIDATION_FAILED))
@@ -249,7 +249,15 @@
                          (leaf-hash-withdraw-nft (contract-of nft-contract) id recipient withdrawal-id height))
                   (err ERR_VALIDATION_LEAF_FAILED))
 
-        (asserts! (try! (as-contract (inner-transfer-or-mint-nft-asset id recipient nft-contract nft-mint-contract))) (err ERR_TRANSFER_FAILED))
+        (asserts!
+            (try!
+                (match nft-mint-contract
+                    mint-contract (as-contract (inner-transfer-or-mint-nft-asset id recipient nft-contract mint-contract))
+                    (as-contract (inner-transfer-without-mint-nft-asset id recipient nft-contract))
+                )
+            )
+            (err ERR_TRANSFER_FAILED)
+        )
 
         (asserts! 
           (finish-withdraw { withdrawal-leaf-hash: withdrawal-leaf-hash, withdrawal-root-hash: withdrawal-root })
@@ -265,7 +273,7 @@
 ;; uses the provided hashes to ensure the requested withdrawal is valid. 
 ;; The function emits a print with details of this event.
 ;; Returns response<bool, int>
-(define-public (withdraw-nft-asset (id uint) (recipient principal) (withdrawal-id uint) (height uint) (nft-contract <nft-trait>) (nft-mint-contract <mint-from-hyperchain-trait>)  (withdrawal-root (buff 32)) (withdrawal-leaf-hash (buff 32)) (sibling-hashes (list 50 (tuple (hash (buff 32)) (is-left-side bool) ) )))
+(define-public (withdraw-nft-asset (id uint) (recipient principal) (withdrawal-id uint) (height uint) (nft-contract <nft-trait>) (nft-mint-contract (optional <mint-from-hyperchain-trait>))  (withdrawal-root (buff 32)) (withdrawal-leaf-hash (buff 32)) (sibling-hashes (list 50 (tuple (hash (buff 32)) (is-left-side bool) ) )))
     (begin
         ;; Check that the asset belongs to the allowed-contracts map
         (unwrap! (map-get? allowed-contracts (contract-of nft-contract)) (err ERR_DISALLOWED_ASSET))
@@ -294,23 +302,6 @@
     )
 )
 
-;; Like `inner-withdraw-nft-asset` but without allowing or requiring a mint function. In order to withdraw, the user must
-;; have the appropriate balance.
-(define-public (inner-withdraw-nft-asset-no-mint (id uint) (recipient principal) (withdrawal-id uint) (height uint) (nft-contract <nft-trait>) (withdrawal-root (buff 32)) (withdrawal-leaf-hash (buff 32)) (sibling-hashes (list 50 (tuple (hash (buff 32)) (is-left-side bool) ) )))
-    (let ((hashes-are-valid (check-withdrawal-hashes withdrawal-root withdrawal-leaf-hash sibling-hashes)))
-        (asserts! (try! hashes-are-valid) (err ERR_VALIDATION_FAILED))
-
-        ;; check that the withdrawal request data matches the supplied leaf hash
-        (asserts! (is-eq withdrawal-leaf-hash
-                         (leaf-hash-withdraw-nft (contract-of nft-contract) id recipient withdrawal-id height))
-                  (err ERR_VALIDATION_LEAF_FAILED))
-
-        (asserts! (try! (as-contract (inner-transfer-without-mint-nft-asset id recipient nft-contract))) (err ERR_TRANSFER_FAILED))
-
-        (ok           (finish-withdraw { withdrawal-leaf-hash: withdrawal-leaf-hash, withdrawal-root-hash: withdrawal-root }))
-    )
-)
-
 ;; Like `withdraw-nft-asset` but without allowing or requiring a mint function. In order to withdraw, the user must
 ;; have the appropriate balance.
 (define-public (withdraw-nft-asset-no-mint (id uint) (recipient principal) (withdrawal-id uint) (height uint) (nft-contract <nft-trait>) (withdrawal-root (buff 32)) (withdrawal-leaf-hash (buff 32)) (sibling-hashes (list 50 (tuple (hash (buff 32)) (is-left-side bool) ) )))
@@ -318,7 +309,7 @@
         ;; Check that the asset belongs to the allowed-contracts map
         (unwrap! (map-get? allowed-contracts (contract-of nft-contract)) (err ERR_DISALLOWED_ASSET))
 
-        (asserts! (try! (inner-withdraw-nft-asset-no-mint id recipient withdrawal-id height nft-contract withdrawal-root withdrawal-leaf-hash sibling-hashes)) (err ERR_TRANSFER_FAILED))
+        (asserts! (try! (inner-withdraw-nft-asset id recipient withdrawal-id height nft-contract none withdrawal-root withdrawal-leaf-hash sibling-hashes)) (err ERR_TRANSFER_FAILED))
 
         ;; Emit a print event
         (print { event: "withdraw-nft", nft-id: id, l1-contract-id: nft-contract, recipient: recipient })

--- a/core-contracts/tests/hyperchains/hyperchains_test.ts
+++ b/core-contracts/tests/hyperchains/hyperchains_test.ts
@@ -378,7 +378,7 @@ Clarinet.test({
                     types.uint(0),
                     types.uint(0),
                     types.principal(nft_contract.contract_id),
-                    types.principal(nft_contract.contract_id),
+                    types.some(types.principal(nft_contract.contract_id)),
                     types.buff(root_hash),
                     types.buff(nft_leaf_hash),
                     types.list([types.tuple({
@@ -408,7 +408,7 @@ Clarinet.test({
                     types.uint(0),
                     types.uint(0),
                     types.principal(nft_contract.contract_id),
-                    types.principal(nft_contract.contract_id),
+                    types.some(types.principal(nft_contract.contract_id)),
                     types.buff(root_hash),
                     types.buff(nft_leaf_hash),
                     types.list([types.tuple({
@@ -1015,7 +1015,7 @@ Clarinet.test({
                     types.uint(2),
                     types.uint(0),
                     types.principal(nft_contract.contract_id),
-                    types.principal(nft_contract.contract_id),
+                    types.some(types.principal(nft_contract.contract_id)),
                     types.buff(root_hash),
                     types.buff(nft_leaf_hash),
                     types.list([types.tuple({
@@ -1112,7 +1112,7 @@ Clarinet.test({
                     types.uint(2),
                     types.uint(0),
                     types.principal(nft_contract.contract_id),
-                    types.principal(nft_contract.contract_id),
+                    types.some(types.principal(nft_contract.contract_id)),
                     types.buff(root_hash),
                     types.buff(nft_leaf_hash),
                     types.list([types.tuple({
@@ -1207,7 +1207,7 @@ Clarinet.test({
                     types.uint(0),
                     types.uint(0),
                     types.principal(nft_contract.contract_id),
-                    types.principal(nft_contract.contract_id),
+                    types.some(types.principal(nft_contract.contract_id)),
                     types.buff(root_hash),
                     types.buff(nft_leaf_hash),
                     types.list([types.tuple({
@@ -1291,7 +1291,7 @@ Clarinet.test({
                     types.uint(0),
                     types.uint(0),                    
                     types.principal(nft_contract.contract_id),
-                    types.principal(nft_contract.contract_id),
+                    types.some(types.principal(nft_contract.contract_id)),
                     types.buff(root_hash),
                     types.buff(nft_leaf_hash),
                     types.list([types.tuple({
@@ -1318,7 +1318,7 @@ Clarinet.test({
                     types.uint(0),
                     types.uint(0),
                     types.principal(nft_contract.contract_id),
-                    types.principal(nft_contract.contract_id),
+                    types.some(types.principal(nft_contract.contract_id)),
                     types.buff(root_hash),
                     types.buff(nft_leaf_hash),
                     types.list([types.tuple({

--- a/core-contracts/tests/hyperchains/hyperchains_test.ts
+++ b/core-contracts/tests/hyperchains/hyperchains_test.ts
@@ -1387,13 +1387,14 @@ Clarinet.test({
 
         // Miner should *not* be able to withdraw NFT asset because the contract doesn't own it.
         block = chain.mineBlock([
-            Tx.contractCall("hyperchains", "withdraw-nft-asset-no-mint",
+            Tx.contractCall("hyperchains", "withdraw-nft-asset",
                 [
                     types.uint(1),
                     types.principal(user.address),
                     types.uint(0),
                     types.uint(0),
                     types.principal(nft_contract.contract_id),
+                    types.none(),
                     types.buff(root_hash),
                     types.buff(nft_leaf_hash),
                     types.list([types.tuple({
@@ -1489,13 +1490,14 @@ Clarinet.test({
 
         // Miner should be able to withdraw NFT asset to original user.
         block = chain.mineBlock([
-            Tx.contractCall("hyperchains", "withdraw-nft-asset-no-mint",
+            Tx.contractCall("hyperchains", "withdraw-nft-asset",
                 [
                     types.uint(1),
                     types.principal(user.address),
                     types.uint(0),
                     types.uint(0),
                     types.principal(nft_contract.contract_id),
+                    types.none(),
                     types.buff(root_hash),
                     types.buff(nft_leaf_hash),
                     types.list([types.tuple({
@@ -1606,13 +1608,14 @@ Clarinet.test({
 
         // Miner should be able to withdraw NFT asset to other_user.
         block = chain.mineBlock([
-            Tx.contractCall("hyperchains", "withdraw-nft-asset-no-mint",
+            Tx.contractCall("hyperchains", "withdraw-nft-asset",
                 [
                     types.uint(1),
                     types.principal(other_user.address),
                     types.uint(0),
                     types.uint(0),
                     types.principal(nft_contract.contract_id),
+                    types.none(),
                     types.buff(root_hash),
                     types.buff(nft_leaf_hash),
                     types.list([types.tuple({


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.
### Description
Before changes in Stacks 2.1, it was not possible to put a trait inside of an `optional`. Now, it is.

So, this PR refactors the `hyperchains.clar` contract to eliminate redundancy in `withdraw-nft-asset`.

### Applicable issues
- fixes #165

### Additional info (benefits, drawbacks, caveats)
TBD:
* rename `hyperchains.clar` to `subnets.clar`

