### PR TITLE
Update project automation - new project id

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -12,5 +12,5 @@ jobs:
     steps:
       - uses: actions/add-to-project@main
         with:
-          project-url: https://github.com/orgs/hirosystems/projects/14
+          project-url: https://github.com/orgs/hirosystems/projects/24
           github-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Classic project has been migrated to https://github.com/orgs/hirosystems/projects/24 .

This should address adding new issues to the project.

