### PR TITLE
feat: Add sender validation to block proposal RPC

### DIFF
--- a/src/net/connection.rs
+++ b/src/net/connection.rs
@@ -319,7 +319,7 @@ struct ConnectionOutbox<P: ProtocolFamily> {
     inflight: VecDeque<ReceiverNotify<P>>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct ConnectionOptions {
     pub inbox_maxlen: usize,
     pub outbox_maxlen: usize,
@@ -404,6 +404,10 @@ pub struct ConnectionOptions {
     pub subnet_validator: Option<Secp256k1PrivateKey>,
     /// the contract used to submit multiparty commits (if a validator)
     pub subnet_signing_contract: Option<QualifiedContractIdentifier>,
+    // Set of participants allowed to propose blocks when using `MultiMiner`
+    // TODO: This should be `HashSet` or `BTreeSet` for more efficient lookup
+    //       Using these types requires deriving `Hash` or `Ord` on `Secp256k1PublicKey`
+    pub allowed_block_proposers: Vec<Secp256k1PublicKey>,
 }
 
 impl std::default::Default for ConnectionOptions {
@@ -492,6 +496,7 @@ impl std::default::Default for ConnectionOptions {
             force_disconnect_interval: None,
             subnet_validator: None,
             subnet_signing_contract: None,
+            allowed_block_proposers: Vec::default(),
         }
     }
 }

--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -38,7 +38,7 @@ use url::{form_urlencoded, Url};
 
 use crate::burnchains::{Address, Txid};
 use crate::chainstate::burn::ConsensusHash;
-use crate::chainstate::stacks::miner::Proposal;
+use crate::chainstate::stacks::miner::SignedProposal;
 use crate::chainstate::stacks::{
     StacksBlock, StacksMicroblock, StacksPublicKey, StacksTransaction,
 };
@@ -2066,7 +2066,7 @@ impl HttpRequestType {
             ));
         }
 
-        let block_proposal: Proposal = serde_json::from_reader(fd).map_err(|_e| {
+        let block_proposal: SignedProposal = serde_json::from_reader(fd).map_err(|_e| {
             net_error::DeserializeError("Failed to parse block proposal JSON body".into())
         })?;
 

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -48,7 +48,7 @@ use crate::chainstate::burn::ConsensusHash;
 use crate::chainstate::coordinator::Error as coordinator_error;
 use crate::chainstate::stacks::db::blocks::MemPoolRejection;
 use crate::chainstate::stacks::index::Error as marf_error;
-use crate::chainstate::stacks::miner::Proposal;
+use crate::chainstate::stacks::miner::SignedProposal;
 use crate::chainstate::stacks::Error as chainstate_error;
 use crate::chainstate::stacks::{
     Error as chain_error, StacksBlock, StacksMicroblock, StacksPublicKey, StacksTransaction,
@@ -1497,7 +1497,7 @@ pub enum HttpRequestType {
         TipRequest,
     ),
     MemPoolQuery(HttpRequestMetadata, MemPoolSyncData, Option<Txid>),
-    BlockProposal(HttpRequestMetadata, Proposal),
+    BlockProposal(HttpRequestMetadata, SignedProposal),
     /// catch-all for any errors we should surface from parsing
     ClientError(HttpRequestMetadata, ClientError),
 }

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -934,9 +934,10 @@ impl ConversationHttp {
         req: &HttpRequestType,
         chainstate: &mut StacksChainState,
         sortdb: &SortitionDB,
-        proposal: &miner::Proposal,
+        signed_proposal: &miner::SignedProposal,
         validator_key: Option<&Secp256k1PrivateKey>,
         signing_contract: Option<&QualifiedContractIdentifier>,
+        options: &ConnectionOptions,
         canonical_stacks_tip_height: u64,
     ) -> Result<(), net_error> {
         let response_metadata =
@@ -947,7 +948,7 @@ impl ConversationHttp {
                 let response = HttpResponseType::BlockProposalInvalid {
                     metadata: response_metadata,
                     error_message:
-                        "Cannot validate block proposal: not configured with validation key".into(),
+                        "Cannot validate block proposal: Not configured with validation key".into(),
                 };
                 return response.send(http, fd);
             }
@@ -959,8 +960,40 @@ impl ConversationHttp {
                 let response = HttpResponseType::BlockProposalInvalid {
                     metadata: response_metadata,
                     error_message:
-                        "Cannot validate block proposal: not configured with a multiparty contract"
+                        "Cannot validate block proposal: Not configured with a multiparty contract"
                             .into(),
+                };
+                return response.send(http, fd);
+            }
+        };
+
+        let pubk_recovered = match signed_proposal.recover_signer_pk() {
+            Ok(key) => key,
+            Err(e) => {
+                let response = HttpResponseType::BlockProposalInvalid {
+                    metadata: response_metadata,
+                    error_message: format!("Cannot validate block proposal: {e}"),
+                };
+                return response.send(http, fd);
+            }
+        };
+
+        // TODO: Replace with lookup in `HashSet`
+        if !options.allowed_block_proposers.contains(&pubk_recovered) {
+            let response = HttpResponseType::BlockProposalInvalid {
+                metadata: response_metadata,
+                error_message:
+                    "Cannot validate block proposal: Not signed by approved block proposer".into(),
+            };
+            return response.send(http, fd);
+        }
+
+        let proposal = match signed_proposal.decode() {
+            Ok(p) => p,
+            Err(e) => {
+                let response = HttpResponseType::BlockProposalInvalid {
+                    metadata: response_metadata,
+                    error_message: format!("Cannot validate block proposal: {e}"),
                 };
                 return response.send(http, fd);
             }
@@ -2817,6 +2850,7 @@ impl ConversationHttp {
                     &proposal,
                     validator_key,
                     signing_contract,
+                    &self.connection.options,
                     network.burnchain_tip.canonical_stacks_tip_height,
                 )?;
                 None

--- a/testnet/stacks-node/src/burnchains/commitment.rs
+++ b/testnet/stacks-node/src/burnchains/commitment.rs
@@ -1,7 +1,7 @@
 use reqwest::StatusCode;
 use serde_json::json;
 use stacks::address::AddressHashMode;
-use stacks::chainstate::stacks::miner::Proposal;
+use stacks::chainstate::stacks::miner::SignedProposal;
 use stacks::chainstate::stacks::{
     StacksPrivateKey, StacksPublicKey, StacksTransaction, StacksTransactionSigner, TransactionAuth,
     TransactionContractCall, TransactionPostConditionMode, TransactionSpendingCondition,
@@ -35,7 +35,7 @@ pub trait Layer1Committer {
     fn propose_block_to(
         &self,
         participant_index: u8,
-        proposal: &Proposal,
+        proposal: &SignedProposal,
     ) -> Result<ClaritySignature, Error>;
     fn make_commit_tx(
         &self,
@@ -367,7 +367,7 @@ impl Layer1Committer for MultiPartyCommitter {
     fn propose_block_to(
         &self,
         participant_index: u8,
-        proposal: &Proposal,
+        proposal: &SignedProposal,
     ) -> Result<ClaritySignature, Error> {
         if self.required_signers == 0
             || participant_index >= self.required_signers - 1
@@ -470,7 +470,7 @@ impl Layer1Committer for DirectCommitter {
     fn propose_block_to(
         &self,
         _participant_index: u8,
-        _proposal: &Proposal,
+        _proposal: &SignedProposal,
     ) -> Result<ClaritySignature, Error> {
         Err(Error::NoSuchParticipant)
     }

--- a/testnet/stacks-node/src/burnchains/l1_events.rs
+++ b/testnet/stacks-node/src/burnchains/l1_events.rs
@@ -9,7 +9,7 @@ use stacks::burnchains::{Burnchain, Error as BurnchainError, Txid};
 use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::coordinator::comm::CoordinatorChannels;
 use stacks::chainstate::stacks::index::ClarityMarfTrieId;
-use stacks::chainstate::stacks::miner::Proposal;
+use stacks::chainstate::stacks::miner::SignedProposal;
 use stacks::chainstate::stacks::StacksTransaction;
 use stacks::codec::StacksMessageCodec;
 use stacks::core::StacksEpoch;
@@ -250,7 +250,7 @@ impl BurnchainController for L1Controller {
     fn propose_block(
         &self,
         participant_index: u8,
-        proposal: &Proposal,
+        proposal: &SignedProposal,
     ) -> Result<ClaritySignature, Error> {
         self.committer
             .propose_block_to(participant_index, proposal)

--- a/testnet/stacks-node/src/burnchains/mock_events.rs
+++ b/testnet/stacks-node/src/burnchains/mock_events.rs
@@ -19,7 +19,7 @@ use stacks::burnchains;
 use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::coordinator::comm::CoordinatorChannels;
 use stacks::chainstate::stacks::index::ClarityMarfTrieId;
-use stacks::chainstate::stacks::miner::Proposal;
+use stacks::chainstate::stacks::miner::SignedProposal;
 use stacks::core::StacksEpoch;
 use stacks::types::chainstate::{BlockHeaderHash, BurnchainHeaderHash, StacksBlockId};
 use stacks::util::sleep_ms;
@@ -533,7 +533,7 @@ impl BurnchainController for MockController {
     fn propose_block(
         &self,
         _participant_index: u8,
-        _proposal: &Proposal,
+        _proposal: &SignedProposal,
     ) -> Result<ClaritySignature, Error> {
         panic!()
     }

--- a/testnet/stacks-node/src/burnchains/mod.rs
+++ b/testnet/stacks-node/src/burnchains/mod.rs
@@ -15,7 +15,7 @@ use stacks::burnchains::Txid;
 use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::burn::BlockSnapshot;
 use stacks::chainstate::stacks::index::ClarityMarfTrieId;
-use stacks::chainstate::stacks::miner::Proposal;
+use stacks::chainstate::stacks::miner::SignedProposal;
 use stacks::core::StacksEpoch;
 use stacks::types::chainstate::BlockHeaderHash;
 use stacks::types::chainstate::BurnchainHeaderHash;
@@ -107,7 +107,7 @@ pub trait BurnchainController {
     fn propose_block(
         &self,
         participant_index: u8,
-        proposal: &Proposal,
+        proposal: &SignedProposal,
     ) -> Result<ClaritySignature, Error>;
 
     fn sync(&mut self, target_block_height_opt: Option<u64>) -> Result<(BurnchainTip, u64), Error>;
@@ -218,7 +218,7 @@ impl BurnchainController for PanicController {
     fn propose_block(
         &self,
         _participant_index: u8,
-        _proposal: &Proposal,
+        _proposal: &SignedProposal,
     ) -> Result<ClaritySignature, Error> {
         panic!()
     }

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -628,9 +628,20 @@ impl Config {
                     subnet_validator: node.mining_key.clone(),
                     ..ConnectionOptions::default()
                 };
-                if let CommitStrategy::MultiMiner { ref contract, .. } = &burnchain.commit_strategy
+                if let CommitStrategy::MultiMiner {
+                    ref contract,
+                    ref other_participants,
+                    ..
+                } = &burnchain.commit_strategy
                 {
                     result_opts.subnet_signing_contract = Some(contract.clone());
+                    result_opts.allowed_block_proposers = other_participants
+                        .iter()
+                        .map(|p| {
+                            Secp256k1PublicKey::from_slice(&p.public_key)
+                                .expect("Failed to load public key")
+                        })
+                        .collect();
                 }
 
                 result_opts

--- a/testnet/stacks-node/src/tests/l1_multiparty.rs
+++ b/testnet/stacks-node/src/tests/l1_multiparty.rs
@@ -19,6 +19,7 @@ use stacks::core::LAYER_1_CHAIN_ID_TESTNET;
 
 use stacks::burnchains::Burnchain;
 
+use stacks::util::secp256k1::Secp256k1PublicKey;
 use stacks::vm::types::PrincipalData;
 use stacks::vm::types::QualifiedContractIdentifier;
 use stacks::vm::types::StandardPrincipalData;
@@ -217,6 +218,8 @@ fn l1_multiparty_2_of_2_integration_test() {
     };
 
     follower_config.connection_options.subnet_signing_contract = Some(multi_party_contract.clone());
+    follower_config.connection_options.allowed_block_proposers =
+        vec![Secp256k1PublicKey::from_private(&MOCKNET_PRIVATE_KEY_2)];
 
     follower_config.add_bootstrap_node(
         "024d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d0766@127.0.0.1:30444",


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/blockstack/stacks-blockchain/blob/master/sip/sip-000-stacks-improvement-proposal-process.md.
-->

### Description
Require block proposals to be signed by an approved signer before proceeding to parse and validate the proposal.  Because validating a block proposal is an expensive operation, allowing anyone to submit a proposal would be a potential Denial of Service attack vector.

See corresponding issue for full details.

### Applicable issues
- fixes #135

### Additional info (benefits, drawbacks, caveats)
- I know I'm going to need to add some integration tests. I'm creating the pull request now in order to get some feedback on the code and some advice on testing
- I chose to hex encode the proposal message before signing it. This allows us to validate the message signature before fully deserializing the JSON. I chose hex encoding over base64 to avoid introducing an extra dependency
- Membership in the set of allowed signers is currently checked using `Vec::contains()`. Depending on the size of the signer set, it may be good to change this to a `HashSet` (or `BTreeSet`), but that would require a code change in stacks-blockchain: Deriving `Hash` (or `Ord`) for `Secp256k1PublicKey`

### Checklist
- [x] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
