### PR TITLE
fix: use bullseye instead of alpine for docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:alpine as build
+FROM rust:bullseye as build
 
 ARG STACKS_NODE_VERSION="No Version Info"
 ARG GIT_BRANCH='No Branch Info'
@@ -8,17 +8,13 @@ WORKDIR /src
 
 COPY . .
 
-RUN apk add --no-cache musl-dev openssl-dev
-
 RUN mkdir /out /contracts
 
 RUN cd testnet/stacks-node && cargo build --features monitoring_prom,slog_json --release
 
 RUN cp target/release/subnet-node /out
 
-FROM alpine:latest
-
-RUN apk add --no-cache openssl musl
+FROM debian:bullseye-backports
 
 COPY --from=build /out/ /bin/
 # Add the core contracts to the image, so that clarinet can retrieve them.


### PR DESCRIPTION
For some reason, the docker image does not work when based on alpine.