### PR TITLE
Withdrawal height

### DIFF
--- a/src/chainstate/stacks/boot/subnet.clar
+++ b/src/chainstate/stacks/boot/subnet.clar
@@ -72,7 +72,8 @@
             amount: amount,
             asset-contract: (contract-of asset),
         })
-        (contract-call? asset burn-for-withdrawal amount sender)
+        (try! (contract-call? asset burn-for-withdrawal amount sender))
+        (ok block-height)
     )
 )
 
@@ -84,7 +85,8 @@
             id: id,
             asset-contract: (contract-of asset),
         })
-        (contract-call? asset burn-for-withdrawal id sender)
+        (try! (contract-call? asset burn-for-withdrawal id sender))
+        (ok block-height)
     )
 )
 
@@ -95,6 +97,7 @@
             sender: sender,
             amount: amount,
         })
-        (stx-transfer? amount sender (as-contract tx-sender))
+        (try! (stx-transfer? amount sender (as-contract tx-sender)))
+        (ok block-height)
     )
 )

--- a/src/chainstate/stacks/boot/subnet.clar
+++ b/src/chainstate/stacks/boot/subnet.clar
@@ -71,6 +71,7 @@
             sender: sender,
             amount: amount,
             asset-contract: (contract-of asset),
+            withdrawal-height: block-height,
         })
         (try! (contract-call? asset burn-for-withdrawal amount sender))
         (ok block-height)
@@ -84,6 +85,7 @@
             sender: sender,
             id: id,
             asset-contract: (contract-of asset),
+            withdrawal-height: block-height,
         })
         (try! (contract-call? asset burn-for-withdrawal id sender))
         (ok block-height)
@@ -96,6 +98,7 @@
             type: "stx",
             sender: sender,
             amount: amount,
+            withdrawal-height: block-height,
         })
         (try! (stx-transfer? amount sender (as-contract tx-sender)))
         (ok block-height)


### PR DESCRIPTION
Return the block height of the withdrawal from the `-withdraw?` functions and add it to the print event.