### PR TITLE
fix: update `server_version`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
           tags: ${{ env.STRETCH_TAG }}
           tag_with_ref: false
           add_git_labels: true
-          build_args: STACKS_NODE_VERSION=${{ github.event.inputs.tag || env.GITHUB_SHA_SHORT }},GIT_BRANCH=${{ env.GITHUB_REF_SHORT }},GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
+          build_args: SUBNET_NODE_VERSION=${{ github.event.inputs.tag || env.GITHUB_SHA_SHORT }},GIT_BRANCH=${{ env.GITHUB_REF_SHORT }},GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
           # Only push if a tag was passed in
           push: ${{ github.event.inputs.tag != '' }}
 
@@ -282,6 +282,6 @@ jobs:
           tags: ${{ env.STRETCH_TAG }}
           tag_with_ref: false
           add_git_labels: true
-          build_args: STACKS_NODE_VERSION=${{ github.event.inputs.tag || env.GITHUB_SHA_SHORT }},GIT_BRANCH=${{ env.GITHUB_REF_SHORT }},GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
+          build_args: SUBNET_NODE_VERSION=${{ github.event.inputs.tag || env.GITHUB_SHA_SHORT }},GIT_BRANCH=${{ env.GITHUB_REF_SHORT }},GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
           # Only push if a tag was passed in
           push: ${{ github.event.inputs.tag != '' }}

--- a/.github/workflows/docker-platforms.yml
+++ b/.github/workflows/docker-platforms.yml
@@ -59,7 +59,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            STACKS_NODE_VERSION=${{ inputs.tag || env.GITHUB_SHA_SHORT }}
+            SUBNET_NODE_VERSION=${{ inputs.tag || env.GITHUB_SHA_SHORT }}
             GIT_BRANCH=${{ env.GITHUB_REF_SHORT }}
             GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
           push: true
@@ -119,7 +119,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            STACKS_NODE_VERSION=${{ inputs.tag || env.GITHUB_SHA_SHORT }}
+            SUBNET_NODE_VERSION=${{ inputs.tag || env.GITHUB_SHA_SHORT }}
             GIT_BRANCH=${{ env.GITHUB_REF_SHORT }}
             GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:bullseye as build
 
-ARG STACKS_NODE_VERSION="No Version Info"
+ARG SUBNET_NODE_VERSION="No Version Info"
 ARG GIT_BRANCH='No Branch Info'
 ARG GIT_COMMIT='No Commit Info'
 

--- a/Dockerfile.stretch
+++ b/Dockerfile.stretch
@@ -1,6 +1,6 @@
 FROM rust:stretch as build
 
-ARG STACKS_NODE_VERSION="No Version Info"
+ARG SUBNET_NODE_VERSION="No Version Info"
 ARG GIT_BRANCH='No Branch Info'
 ARG GIT_COMMIT='No Commit Info'
 

--- a/build-scripts/Dockerfile.linux-arm64
+++ b/build-scripts/Dockerfile.linux-arm64
@@ -1,6 +1,6 @@
 FROM rust:stretch as build
 
-ARG STACKS_NODE_VERSION="No Version Info"
+ARG SUBNET_NODE_VERSION="No Version Info"
 ARG GIT_BRANCH='No Branch Info'
 ARG GIT_COMMIT='No Commit Info'
 

--- a/build-scripts/Dockerfile.linux-armv7
+++ b/build-scripts/Dockerfile.linux-armv7
@@ -1,6 +1,6 @@
 FROM rust:stretch as build
 
-ARG STACKS_NODE_VERSION="No Version Info"
+ARG SUBNET_NODE_VERSION="No Version Info"
 ARG GIT_BRANCH='No Branch Info'
 ARG GIT_COMMIT='No Commit Info'
 

--- a/build-scripts/Dockerfile.linux-musl-x64
+++ b/build-scripts/Dockerfile.linux-musl-x64
@@ -1,6 +1,6 @@
 FROM rust:stretch as build
 
-ARG STACKS_NODE_VERSION="No Version Info"
+ARG SUBNET_NODE_VERSION="No Version Info"
 ARG GIT_BRANCH='No Branch Info'
 ARG GIT_COMMIT='No Commit Info'
 

--- a/build-scripts/Dockerfile.linux-x64
+++ b/build-scripts/Dockerfile.linux-x64
@@ -1,6 +1,6 @@
 FROM rust:stretch as build
 
-ARG STACKS_NODE_VERSION="No Version Info"
+ARG SUBNET_NODE_VERSION="No Version Info"
 ARG GIT_BRANCH='No Branch Info'
 ARG GIT_COMMIT='No Commit Info'
 

--- a/build-scripts/Dockerfile.macos-arm64
+++ b/build-scripts/Dockerfile.macos-arm64
@@ -1,6 +1,6 @@
 FROM rust:bullseye as build
 
-ARG STACKS_NODE_VERSION="No Version Info"
+ARG SUBNET_NODE_VERSION="No Version Info"
 ARG GIT_BRANCH='No Branch Info'
 ARG GIT_COMMIT='No Commit Info'
 

--- a/build-scripts/Dockerfile.macos-x64
+++ b/build-scripts/Dockerfile.macos-x64
@@ -1,6 +1,6 @@
 FROM rust:bullseye as build
 
-ARG STACKS_NODE_VERSION="No Version Info"
+ARG SUBNET_NODE_VERSION="No Version Info"
 ARG GIT_BRANCH='No Branch Info'
 ARG GIT_COMMIT='No Commit Info'
 

--- a/build-scripts/Dockerfile.windows-x64
+++ b/build-scripts/Dockerfile.windows-x64
@@ -1,6 +1,6 @@
 FROM rust:stretch as build
 
-ARG STACKS_NODE_VERSION="No Version Info"
+ARG SUBNET_NODE_VERSION="No Version Info"
 ARG GIT_BRANCH='No Branch Info'
 ARG GIT_COMMIT='No Commit Info'
 

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -219,8 +219,8 @@ impl RPCPeerInfoData {
         genesis_chainstate_hash: &Sha256Sum,
     ) -> RPCPeerInfoData {
         let server_version = version_string(
-            "stacks-node",
-            option_env!("STACKS_NODE_VERSION")
+            "subnet-node",
+            option_env!("SUBNET_NODE_VERSION")
                 .or(option_env!("CARGO_PKG_VERSION"))
                 .unwrap_or("0.0.0.0"),
         );

--- a/testnet/stacks-node/src/main.rs
+++ b/testnet/stacks-node/src/main.rs
@@ -149,8 +149,8 @@ fn main() {
 
 fn version() -> String {
     stacks::version_string(
-        "stacks-node",
-        option_env!("STACKS_NODE_VERSION")
+        "subnet-node",
+        option_env!("SUBNET_NODE_VERSION")
             .or(option_env!("CARGO_PKG_VERSION"))
             .unwrap_or("0.0.0.0"),
     )


### PR DESCRIPTION
The `/v2/info` endpoint is updated to report "subnet-node" instead of
"stacks-node".