### PR TITLE
fix: Return non-zero value for `burn_block_time` in v1 API

### DIFF
--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -174,7 +174,9 @@ impl BurnchainBlock {
     }
 
     pub fn timestamp(&self) -> u64 {
-        0
+        match self {
+            BurnchainBlock::StacksSubnetBlock(b) => b.burn_block_time,
+        }
     }
 
     pub fn header(&self) -> BurnchainBlockHeader {

--- a/src/burnchains/events.rs
+++ b/src/burnchains/events.rs
@@ -85,11 +85,12 @@ impl std::fmt::Debug for NewBlock {
     fn fmt(&self, f: &mut Formatter) -> Result<(), std::fmt::Error> {
         write!(
             f,
-            "NewBlock(hash={:?}, parent_hash={:?}, block_height={}, num_events={})",
+            "NewBlock(hash={:?}, parent_hash={:?}, block_height={}, num_events={}, burn_block_time={})",
             &self.index_block_hash,
             &self.parent_index_block_hash,
             self.block_height,
-            self.events.len()
+            self.events.len(),
+            self.burn_block_time
         )
     }
 }
@@ -545,6 +546,7 @@ impl StacksSubnetBlock {
             index_block_hash,
             parent_index_block_hash,
             block_height,
+            burn_block_time,
             ..
         } = b;
 
@@ -604,6 +606,7 @@ impl StacksSubnetBlock {
             current_block: index_block_hash,
             parent_block: parent_index_block_hash,
             block_height,
+            burn_block_time,
             ops,
         }
     }

--- a/src/burnchains/mod.rs
+++ b/src/burnchains/mod.rs
@@ -317,6 +317,7 @@ pub struct StacksSubnetBlock {
     pub current_block: StacksBlockId,
     pub parent_block: StacksBlockId,
     pub block_height: u64,
+    pub burn_block_time: u64,
     pub ops: Vec<StacksSubnetOp>,
 }
 

--- a/src/burnchains/test.rs
+++ b/src/burnchains/test.rs
@@ -433,6 +433,7 @@ impl TestBurnchainBlock {
             parent_block: StacksBlockId(self.parent_snapshot.burn_header_hash.0.clone()),
             ops: vec![],
             block_height: self.block_height,
+            burn_block_time: 0,
         };
         let block = BurnchainBlock::StacksSubnetBlock(mock_bitcoin_block);
 
@@ -487,6 +488,7 @@ impl TestBurnchainBlock {
             parent_block: StacksBlockId(self.parent_snapshot.burn_header_hash.0.clone()),
             ops: vec![],
             block_height: self.block_height,
+            burn_block_time: 0,
         };
         let block = BurnchainBlock::StacksSubnetBlock(mock_bitcoin_block);
 


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/blockstack/stacks-blockchain/blob/master/sip/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

API endpoints `extended/v1/block` and `extended/v1/block` were empty/zero values for the following variables:

```json
{
      "burn_block_time": 0,
      "burn_block_time_iso": "",
      "parent_burn_block_time": 0,
      "parent_burn_block_time_iso": ""
}
```

This was due to failing to parse and store the timestamp from the burnchain block in `StacksSubnetBlock::from_new_block_event()`. This PR fixes this issue so that these variables are now proper Unix and ISO-8601 timestamps:

```json
{
      "burn_block_time": 1679512099,
      "burn_block_time_iso": "2023-03-22T19:08:19.000Z",
      "parent_burn_block_time": 1679512039,
      "parent_burn_block_time_iso": "2023-03-22T19:07:19.000Z",
}
```

### Applicable issues
- fixes #239 

### Additional info (benefits, drawbacks, caveats)

We still report `0` for genesis block. Not sure if that's a problem

### Checklist
- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
