### PR TITLE
Fix: handful of resiliency fixes

### DIFF
--- a/src/burnchains/mod.rs
+++ b/src/burnchains/mod.rs
@@ -457,7 +457,7 @@ pub enum Error {
     /// Thread channel error
     ThreadChannelError,
     /// Missing headers
-    MissingHeaders,
+    MissingHeaders(BurnchainHeaderHash),
     /// Missing parent block
     MissingParentBlock,
     /// Remote burnchain peer has misbehaved
@@ -480,7 +480,7 @@ impl fmt::Display for Error {
             Error::DBError(ref dbe) => fmt::Display::fmt(dbe, f),
             Error::DownloadError(ref btce) => fmt::Display::fmt(btce, f),
             Error::ParseError => write!(f, "Parse error"),
-            Error::MissingHeaders => write!(f, "Missing block headers"),
+            Error::MissingHeaders(ref bh) => write!(f, "Missing block headers for block {}", bh),
             Error::MissingParentBlock => write!(f, "Missing parent block"),
             Error::ThreadChannelError => write!(f, "Error in thread channel"),
             Error::BurnchainPeerBroken => write!(f, "Remote burnchain peer has misbehaved"),
@@ -501,7 +501,7 @@ impl error::Error for Error {
             Error::DBError(ref e) => Some(e),
             Error::DownloadError(ref _e) => None,
             Error::ParseError => None,
-            Error::MissingHeaders => None,
+            Error::MissingHeaders(_) => None,
             Error::MissingParentBlock => None,
             Error::ThreadChannelError => None,
             Error::BurnchainPeerBroken => None,

--- a/src/net/download.rs
+++ b/src/net/download.rs
@@ -727,7 +727,7 @@ impl BlockDownloader {
                 return Ok(vec![]);
             }
 
-            debug!("Begin headers load");
+            trace!("Begin headers load");
             let begin_ts = get_epoch_time_ms();
             let last_ancestor = SortitionDB::get_ancestor_snapshot(
                 &ic,
@@ -766,7 +766,7 @@ impl BlockDownloader {
                 );
             }
             let end_ts = get_epoch_time_ms();
-            debug!("End headers load ({} ms)", end_ts.saturating_sub(begin_ts));
+            trace!("End headers load ({} ms)", end_ts.saturating_sub(begin_ts));
 
             // update cache
             SortitionDB::merge_block_header_cache(header_cache, &local_blocks);

--- a/src/net/inv.rs
+++ b/src/net/inv.rs
@@ -1225,8 +1225,8 @@ impl PeerNetwork {
     pub fn num_inventory_reward_cycles(&self) -> u64 {
         let tip_block_height = self.burnchain_tip.block_height;
         self.burnchain
-            .pox_constants
-            .num_sync_cycles_to_height(tip_block_height)
+            .block_height_to_reward_cycle(tip_block_height)
+            .unwrap_or(0)
     }
 
     /// Try to make a GetPoxInv request for the target reward cycle for this peer.

--- a/src/net/inv.rs
+++ b/src/net/inv.rs
@@ -1459,7 +1459,7 @@ impl PeerNetwork {
             Ok(s) => s,
             Err(net_error::NotFoundError) => {
                 // we're not caught up
-                debug!("{:?}: Will not send GetBlocksInv to {:?}, since we are not caught up to block height {}", &self.local_peer, nk, target_block_height);
+                warn!("{:?}: Will not send GetBlocksInv to {:?}, since we are not caught up to block height {}", &self.local_peer, nk, target_block_height);
                 return Ok(None);
             }
             Err(e) => {
@@ -1487,7 +1487,7 @@ impl PeerNetwork {
                 )? {
                     0 => {
                         // cannot ask this peer for any blocks in this reward cycle
-                        debug!("{:?}: no blocks available from {} at cycle {} (which starts at height {})", &self.local_peer, nk, target_block_reward_cycle, self.burnchain.reward_cycle_to_block_height(target_block_reward_cycle));
+                        warn!("{:?}: no blocks available from {} at cycle {} (which starts at height {})", &self.local_peer, nk, target_block_reward_cycle, self.burnchain.reward_cycle_to_block_height(target_block_reward_cycle));
                         return Ok(None);
                     }
                     x => x,
@@ -1589,15 +1589,10 @@ impl PeerNetwork {
         nk: &NeighborKey,
         stats: &NeighborBlockStats,
     ) -> Result<Option<(u64, GetBlocksInv)>, net_error> {
-        if stats.block_reward_cycle <= stats.inv.num_reward_cycles {
-            self.make_getblocksinv(sortdb, nk, stats, stats.block_reward_cycle)
-                .and_then(|getblocksinv_opt| {
-                    Ok(getblocksinv_opt
-                        .map(|getblocksinv| (stats.block_reward_cycle, getblocksinv)))
-                })
-        } else {
-            Ok(None)
-        }
+        self.make_getblocksinv(sortdb, nk, stats, stats.block_reward_cycle)
+            .and_then(|getblocksinv_opt| {
+                Ok(getblocksinv_opt.map(|getblocksinv| (stats.block_reward_cycle, getblocksinv)))
+            })
     }
 
     /// Determine at which reward cycle to begin scanning inventories

--- a/testnet/stacks-node/src/burnchains/db_indexer.rs
+++ b/testnet/stacks-node/src/burnchains/db_indexer.rs
@@ -58,7 +58,7 @@ pub fn get_header_for_hash(
 
     match row_option {
         Some(row) => Ok(row),
-        None => Err(BurnchainError::MissingHeaders),
+        None => Err(BurnchainError::MissingHeaders(hash.clone())),
     }
 }
 
@@ -158,6 +158,13 @@ fn process_reorg(
     old_tip: &BurnBlockIndexRow,
 ) -> Result<u64, BurnchainError> {
     // Step 1: Set `is_canonical` to true for ancestors of the new tip.
+    info!(
+        "Processing Stacks (L1) chain reorg";
+        "old_tip_id" => %old_tip.header_hash,
+        "old_tip_height" => old_tip.height,
+        "new_tip_id" => %new_tip.header_hash,
+        "new_tip_height" => new_tip.height,
+    );
     let mut up_cursor = BurnchainHeaderHash(new_tip.parent_header_hash());
     let greatest_common_ancestor = loop {
         let cursor_header = get_header_for_hash(&transaction, &up_cursor)?;
@@ -217,12 +224,20 @@ fn find_first_canonical_ancestor(
 struct DBBurnBlockInputChannel {
     /// Path to the db file underlying this logic.
     output_db_path: String,
+    config: BurnchainConfig,
 }
 
 impl BurnchainChannel for DBBurnBlockInputChannel {
     /// Add `new_block` to the `block_index` database.
     fn push_block(&self, new_block: NewBlock) -> Result<(), BurnchainError> {
-        debug!("BurnchainChannel: try pushing; new_block {:?}", &new_block);
+        if self.config.first_burn_header_height > new_block.block_height {
+            debug!("BurnchainChannel skipping new_block event before first_burn_header_height";
+                    "first_burn_height" => %self.config.first_burn_header_height,
+                    "new_block_height" => new_block.block_height,
+            );
+            return Ok(());
+        }
+        debug!("BurnchainChannel: push_block"; "new_block_ht" => new_block.block_height, "new_block_id" => %new_block.index_block_hash);
         // Re-open the connection.
         let open_flags = OpenFlags::SQLITE_OPEN_READ_WRITE;
         let mut connection = sqlite_open(&self.output_db_path, open_flags, true)?;
@@ -518,6 +533,7 @@ impl BurnchainIndexer for DBBurnchainIndexer {
     fn get_channel(&self) -> Arc<(dyn BurnchainChannel + 'static)> {
         Arc::new(DBBurnBlockInputChannel {
             output_db_path: self.get_headers_path(),
+            config: self.config.clone(),
         })
     }
 

--- a/testnet/stacks-node/src/burnchains/mock_events.rs
+++ b/testnet/stacks-node/src/burnchains/mock_events.rs
@@ -672,7 +672,7 @@ impl BurnchainIndexer for MockIndexer {
 
     fn get_headers_height(&self) -> Result<u64, BurnchainError> {
         if self.blocks.len() == 0 {
-            Err(BurnchainError::MissingHeaders)
+            Err(BurnchainError::MissingHeaders(BurnchainHeaderHash([0; 32])))
         } else {
             Ok(self.minimum_recorded_height + (self.blocks.len() as u64) - 1)
         }
@@ -724,7 +724,7 @@ impl BurnchainIndexer for MockIndexer {
         end_block: u64,
     ) -> Result<Vec<MockHeader>, BurnchainError> {
         if start_block < self.minimum_recorded_height {
-            return Err(BurnchainError::MissingHeaders);
+            return Err(BurnchainError::MissingHeaders(BurnchainHeaderHash([0; 32])));
         }
         if end_block < start_block {
             return Err(BurnchainError::BurnchainPeerBroken);


### PR DESCRIPTION
This PR fixes a handful of issues that cropped up while running on testnet.

1. Ignoring L1 blocks before the first block height: this ensures that if a reorg occurs before the first block height, the node doesn't need to backtrack (potentially through blocks it hasn't received data for).
2. The neon run loop needs to increment the "target_burnchain_block", even without PoX reward cycles. To do this, we just use a constant value.
3. On restarting a paired `stacks-node` and `subnet-node`, the `stacks-node` may re-broadcast the last event it broadcasted. In such cases, the `subnet-node` should just drop the duplicate data.
4. The p2p inventory sync needs to send GetBlockInv messages even though the PoX reward cycle sync is broken in subnets (because there's no PoX cycles!)

