### PR TITLE
Fix: Rename `withdrawal_id` to `withdrawal-id`

### DIFF
--- a/src/clarity_vm/withdrawal.rs
+++ b/src/clarity_vm/withdrawal.rs
@@ -73,7 +73,10 @@ pub fn generate_key_from_event(
 
         if let Value::Tuple(ref mut data) = event_data.value {
             let data_map = &mut data.data_map;
-            data_map.insert("withdrawal_id".into(), Value::UInt(withdrawal_id as u128));
+            data_map.insert(
+                "withdrawal-id".into(),
+                Value::UInt(u128::from(withdrawal_id)),
+            );
             let event_type = data_map.get("type")?.clone().expect_ascii();
 
             return match event_type.as_str() {

--- a/testnet/stacks-node/src/tests/l1_observer_test.rs
+++ b/testnet/stacks-node/src/tests/l1_observer_test.rs
@@ -1030,7 +1030,7 @@ fn l1_deposit_and_withdraw_asset_integration_test() {
     let mut withdrawal_height = 0;
     for (height, event) in withdraw_events {
         withdrawal_height = height;
-        let withdrawal_id = event.get("withdrawal_id").unwrap().clone().expect_u128() as u32;
+        let withdrawal_id = event.get("withdrawal-id").unwrap().clone().expect_u128() as u32;
         match event.get("type").unwrap().clone().expect_ascii().as_str() {
             "ft" => ft_withdrawal_id = withdrawal_id,
             "nft" => nft_withdrawal_id = withdrawal_id,
@@ -1561,7 +1561,7 @@ fn l1_deposit_and_withdraw_stx_integration_test() {
     let (withdrawal_height, withdrawal) = withdraw_events.pop().unwrap();
 
     let withdrawal_id = withdrawal
-        .get("withdrawal_id")
+        .get("withdrawal-id")
         .unwrap()
         .clone()
         .expect_u128() as u32;


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/blockstack/stacks-blockchain/blob/master/sip/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

Rename `withdrawal_id` to `withdrawal-id`, because we should be consistently using kebab-case for Clarity values 

### Applicable issues
- fixes #245 

### Additional info (benefits, drawbacks, caveats)

I'm not sure if the following lines in `http.rs` should be changed also:

```rust
HttpRequestType::GetWithdrawalStx { .. } => {
    "/v2/withdrawal/stx/:block-height/:sender/:withdrawal_id/:amount"
}
HttpRequestType::BlockProposal(..) => PATH_STR_POST_BLOCK_PROPOSAL,
HttpRequestType::GetWithdrawalFt { .. } => {
    "/v2/withdrawal/ft/:block-height/:sender/:withdrawal_id/:contract_address/:contract_name/:amount"
}
HttpRequestType::GetWithdrawalNft { .. } => {
    "/v2/withdrawal/nft/:block-height/:sender/:withdrawal_id/:contract_address/:contract_name/:id"
}
```

I don't understand this syntax and have no idea what it means

### Checklist
- [x] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
