### PR TITLE
fix: support versioned contract transactions

### DIFF
--- a/src/chainstate/stacks/mod.rs
+++ b/src/chainstate/stacks/mod.rs
@@ -618,6 +618,8 @@ pub enum TransactionPayloadID {
     ContractCall = 2,
     PoisonMicroblock = 3,
     Coinbase = 4,
+    CoinbaseToAltRecipient = 5,
+    VersionedSmartContract = 6,
 }
 
 /// Encoding of an asset type identifier

--- a/src/chainstate/stacks/transaction.rs
+++ b/src/chainstate/stacks/transaction.rs
@@ -117,11 +117,10 @@ fn ClarityVersion_consensus_serialize<W: Write>(
     version: &ClarityVersion,
     fd: &mut W,
 ) -> Result<(), codec_error> {
-    match *version {
-        ClarityVersion::Clarity1 => write_next(fd, &1u8)?,
-        ClarityVersion::Clarity2 => write_next(fd, &2u8)?,
+    match version {
+        ClarityVersion::Clarity1 => write_next(fd, &1u8),
+        ClarityVersion::Clarity2 => write_next(fd, &2u8),
     }
-    Ok(())
 }
 
 fn ClarityVersion_consensus_deserialize<R: Read>(


### PR DESCRIPTION
The upstream changes for 2.1 added support to pass the Clarity version when deploying a contract. Using this new transaction type is the default from stacks.js, so it makes sense to support this new type in the subnet as well.