### PR TITLE
ci: Push to DockerHub on branch commits, but only if we have credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,8 +239,8 @@ jobs:
           tag_with_ref: false
           add_git_labels: true
           build_args: SUBNET_NODE_VERSION=${{ github.event.inputs.tag || env.GITHUB_SHA_SHORT }},GIT_BRANCH=${{ env.GITHUB_REF_SHORT }},GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
-          # Only push if a tag was passed in
-          push: ${{ github.event.inputs.tag != '' }}
+          # Only push if ( we have DockerHub credentials and ((a tag was passed in) or (we're building a non-master branch))
+          push: ${{ secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_PASSWORD && (github.event.inputs.tag || (github.ref != 'refs/heads/master')) }}
 
   # Build docker image, tag it with the git tag and `latest` if running on master branch, and publish under the following conditions
   # Will publish if:
@@ -283,5 +283,5 @@ jobs:
           tag_with_ref: false
           add_git_labels: true
           build_args: SUBNET_NODE_VERSION=${{ github.event.inputs.tag || env.GITHUB_SHA_SHORT }},GIT_BRANCH=${{ env.GITHUB_REF_SHORT }},GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
-          # Only push if a tag was passed in
-          push: ${{ github.event.inputs.tag != '' }}
+          # Only push if ( we have DockerHub credentials and ((a tag was passed in) or (we're building a non-master branch))
+          push: ${{ secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_PASSWORD && (github.event.inputs.tag || (github.ref != 'refs/heads/master')) }}


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/blockstack/stacks-blockchain/blob/master/sip/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

Push to DockerHub on branch commits, but only if we have credentials. This will make it easier to develop using `clarinet integrate`, which by default pulls Subnets from DockerHub

### Additional info (benefits, drawbacks, caveats)

This PR reverts a change I made in #214, but only attempts the push to DockerHub if we have credentials, so we won't get CI failures when working in forked repos