### PR TITLE
ci: Add explicit `!= ''` comparisons to test if strings are non-empty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,7 @@ jobs:
           add_git_labels: true
           build_args: SUBNET_NODE_VERSION=${{ github.event.inputs.tag || env.GITHUB_SHA_SHORT }},GIT_BRANCH=${{ env.GITHUB_REF_SHORT }},GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
           # Only push if ( we have DockerHub credentials and ((a tag was passed in) or (we're building a non-master branch))
-          push: ${{ secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_PASSWORD && (github.event.inputs.tag || (github.ref != 'refs/heads/master')) }}
+          push: ${{ (secrets.DOCKERHUB_USERNAME != '') && (secrets.DOCKERHUB_PASSWORD != '') && ((github.event.inputs.tag != '') || (github.ref != 'refs/heads/master')) }}
 
   # Build docker image, tag it with the git tag and `latest` if running on master branch, and publish under the following conditions
   # Will publish if:
@@ -284,4 +284,4 @@ jobs:
           add_git_labels: true
           build_args: SUBNET_NODE_VERSION=${{ github.event.inputs.tag || env.GITHUB_SHA_SHORT }},GIT_BRANCH=${{ env.GITHUB_REF_SHORT }},GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
           # Only push if ( we have DockerHub credentials and ((a tag was passed in) or (we're building a non-master branch))
-          push: ${{ secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_PASSWORD && (github.event.inputs.tag || (github.ref != 'refs/heads/master')) }}
+          push: ${{ (secrets.DOCKERHUB_USERNAME != '') && (secrets.DOCKERHUB_PASSWORD != '') && ((github.event.inputs.tag != '') || (github.ref != 'refs/heads/master')) }}


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/blockstack/stacks-blockchain/blob/master/sip/sip-000-stacks-improvement-proposal-process.md.
-->

### Description
Fixes the `docker push` step of CI by explicitly checking if a string is empty using `!=`, rather than relying on an implicit cast

### Additional info (benefits, drawbacks, caveats)
This fixes an issue introduced by #258. If you check [here](https://github.com/hirosystems/stacks-subnets/actions/runs/4735274334), when I made these changes they worked fine. I'm not sure what changed since them to make it fail now.

### Checklist
- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
