### PR TITLE
Walkthrough guide edits

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -286,7 +286,7 @@ To submit transactions to Hiro's Stacks node and subnet node, we will use the fo
 ```sh
 mkdir scripts
 cd scripts
-touch {publish.js,register.js,mint.js,deposit.js,transfer.js,withdraw-l2.js,withdraw-l1.js,verify.js}
+touch {publish,register,mint,deposit,transfer,withdraw-l2,withdraw-l1,verify}.js
 ```
 
 Then we will initialize a Node.js project and install the Stacks.js dependencies:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -243,7 +243,6 @@ subnet_node_image_url = "hirosystems/stacks-subnets:0.4.2"
 subnet_api_image_url = "hirosystems/stacks-blockchain-api:7.1.0-beta.2"
 ```
 
-These settings are modifiable if you'd like to test a custom subnet implementation.
 
 Once the configuration is complete, run the following command to start the
 devnet environment:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -132,7 +132,11 @@ Note that this contract implements the `mint-from-subnet-trait` and the SIP-009 
 
 Next, we will manually create the subnet contract at _./contracts/simple-nft-l2.clar_ with `touch contracts/simple-nft-l2.clar` in terminal.
 
-As mentioned earlier, Clarinet does not support deploying subnet contracts yet, so this manually created Clarity contract file will be published to the subnet with a Stacks.js script created later in this guide. Include this Clarity code in the contract:
+Next, we will create the subnet contract at _./contracts/simple-nft-l2.clar_. As mentioned earlier, Clarinet does not support deploying subnet contracts yet, so we will manually create this file and add the following contents:
+
+:::note
+You can use Clarinet to create the Clarity file at the specific location by entering into the terminal `clarinet contract new simple-nft-l2` or you can manually create a new file. But note that Clarinet will not deploy this contract to the subnet; instead, in a later step, you will write and run a Stacks.js script that communicates to the subnet node.
+:::
 
 ```clarity
 (define-constant CONTRACT_OWNER tx-sender)
@@ -223,6 +227,8 @@ Uncomment, or add, the following line under `[devnet]`:
 ```toml
 enable_subnet_node = true
 ```
+
+### Subnet Settings
 
 Also, in that file, we can see a few default settings that `clarinet` will be using for our subnet. `subnet_contract_id` specifies the L1 contract with which the subnet will be interacting. This will be automatically downloaded from the network and deployed by `clarinet` but you can take a look at it [here](https://explorer.hiro.so/txid/0x7d8a5d649d0f2b7583a456225c2e98b40ba62a124c5187f6dbfa563592b24e76?chain=testnet) if interested.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -272,11 +272,13 @@ By the end of this section, we will have these several scripts that correspond t
 - _withdraw-l1.js_ - the second step to withdrawal is to undeposit the NFT asset from L1 interface contract
 - _verify.js_ - querying the current owner of an NFT
 
+
 To submit transactions to Hiro's Stacks node and subnet node, we will use the following simple scripts. We will save them in a new directory, _./scripts/_.
 
 ```sh
 mkdir scripts
 cd scripts
+touch {publish.js,register.js,mint.js,deposit.js,transfer.js,withdraw-l2.js,withdraw-l1.js,verify.js}
 ```
 
 Then we will initialize a Node.js project and install the Stacks.js dependencies:
@@ -749,11 +751,12 @@ First, we will publish the L2 NFT contract to the subnet:
 node ./publish.js simple-nft-l2 ../contracts/simple-nft-l2.clar 2 0
 ```
 
-Clarinet's interface doesn't show the transactions on the subnet, but we can see
-the transaction in our local explorer instance. In a web browser, visit
-http://localhost:8000. By default, it will open the explorer for the devnet L1.
-To switch to the subnet, select "Network" in the top right, then "Add a
-network." In the popup, choose a name, e.g., "Devnet Subnet," then for the URL, use "http://localhost:13999". You will know this contract deployment succeeded when you see the contract deploy transaction for "simple-nft-l2" in the list of confirmed transactions.
+Clarinet's terminal interface does not show the transactions on the subnet, but we can see the transaction in our local explorer instance. In a web browser, visit http://localhost:8000. By default, it will open the Explorer for the devnet L1. To switch to the subnet, select "Network" in the top right, then "Add a network." In the popup, choose a name, e.g., "Devnet Subnet" and then for the URL, use "http://localhost:13999". You will know this contract deployment succeeded when you see the contract deploy transaction for "simple-nft-l2" in the list of confirmed transactions. Be sure to confirm transactions before proceeding.
+
+:::note
+
+Each of these scripts depend upon the prior transaction to be published to either the L1 devnet or the L2 subnet before the next transaction can be completed successfully (for instance, the `register.js` transaction must be published to a devnet block before the `mint.js` transaction can be called). The Explorer shows these transactions in each new block; be sure to occasionally refresh the Explorer.
+:::
 
 ![contract deploy confirmed](images/subnets-deployment-confirmed.png)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -230,7 +230,10 @@ enable_subnet_node = true
 
 ### Optional Settings
 
-Also, in that file, we can see a few default settings that `clarinet` will be using for our subnet. `subnet_contract_id` specifies the L1 contract with which the subnet will be interacting. This will be automatically downloaded from the network and deployed by `clarinet` but you can take a look at it [here](https://explorer.hiro.so/txid/0x7d8a5d649d0f2b7583a456225c2e98b40ba62a124c5187f6dbfa563592b24e76?chain=testnet) if interested.
+Also, in that file, we can see a few default settings that `clarinet` will be using for our subnet.
+It is not necessary to modify any of these settings, but doing so allows you to customize your test environment.
+`subnet_contract_id` specifies the L1 contract with which the subnet will be interacting.
+This will be automatically downloaded from the network and deployed by `clarinet` but you can take a look at it [here](https://explorer.hiro.so/txid/0x7d8a5d649d0f2b7583a456225c2e98b40ba62a124c5187f6dbfa563592b24e76?chain=testnet) if interested.
 
 ```toml
 subnet_contract_id = "ST13F481SBR0R7Z6NMMH8YV2FJJYXA5JPA0AD3HP9.subnet-v1-1"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -228,7 +228,7 @@ Uncomment, or add, the following line under `[devnet]`:
 enable_subnet_node = true
 ```
 
-### Subnet Settings
+### Optional Settings
 
 Also, in that file, we can see a few default settings that `clarinet` will be using for our subnet. `subnet_contract_id` specifies the L1 contract with which the subnet will be interacting. This will be automatically downloaded from the network and deployed by `clarinet` but you can take a look at it [here](https://explorer.hiro.so/txid/0x7d8a5d649d0f2b7583a456225c2e98b40ba62a124c5187f6dbfa563592b24e76?chain=testnet) if interested.
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -4,7 +4,7 @@ title: Overview
 
 # Overview
 
-A subnet is a layer-2 scaling solution for the Stacks blockchain, offering low latency and high throughput at the expense of centralization to a federated set of miners, enabling developers to build fast and reliable user experiences on Stacks.
+A subnet is a layer-2 scaling solution for the Stacks blockchain, offering low latency and high throughput, enabling developers to build fast and reliable user experiences on Stacks.
 
 ## Background
 


### PR DESCRIPTION
### Description

Penultimate changes to Getting Started guide before preview announcement to Discord on Friday. Changes pertain mostly to docker tags, also some additional clarifying language. 

PR is not complete, needs resolution of `$ node ./verify.js 2` bug which returns `none` instead of expected account, one of the last steps in the guide. 