### PR TITLE
Feat/subnet contract versioning

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,9 @@
+# Build subnets node
+build *args:
+    #!/usr/bin/env bash
+    pushd testnet/stacks-node
+    cargo build {{args}}
+    popd
+
+# Build release version subnets node
+build-release: (build "--features" "monitoring_prom,slog_json" "--release")

--- a/Justfile
+++ b/Justfile
@@ -1,3 +1,14 @@
+docker_tag := "latest"
+docker_registry := "localhost:5000"
+docker_image := docker_registry + "/subnet-node:" + docker_tag
+
+# Print help message
+help:
+    @just --list --unsorted
+    @echo ""
+    @echo "Available variables and default values:"
+    @just --evaluate
+
 # Build subnets node
 build *args:
     #!/usr/bin/env bash
@@ -7,3 +18,11 @@ build *args:
 
 # Build release version subnets node
 build-release: (build "--features" "monitoring_prom,slog_json" "--release")
+
+# Build docker image
+docker-build:
+    docker build -t {{docker_image}} .
+    
+# Build and push docker image
+docker-push: docker-build
+    docker push {{docker_image}}

--- a/core-contracts/contracts/multi-miner.clar
+++ b/core-contracts/contracts/multi-miner.clar
@@ -30,7 +30,7 @@
 ;; Return error if subnet contract version not supported
 (define-read-only (check-subnet-contract-version) (
     let (
-        (subnet-contract-version (contract-call? .subnet get-version))
+        (subnet-contract-version (contract-call? .subnet-v2-0-0 get-version))
     )
 
     ;; Check subnet contract version is greater than min supported version
@@ -111,6 +111,6 @@
          ;; check that we have enough signatures
          (try! (check-miners (append (get signers signer-principals) tx-sender)))
          ;; execute the block commit
-         (as-contract (contract-call? .subnet commit-block (get block block-data) (get subnet-block-height block-data) (get target-tip block-data) (get withdrawal-root block-data)))
+         (as-contract (contract-call? .subnet-v2-0-0 commit-block (get block block-data) (get subnet-block-height block-data) (get target-tip block-data) (get withdrawal-root block-data)))
     )
 )

--- a/core-contracts/contracts/subnet.clar
+++ b/core-contracts/contracts/subnet.clar
@@ -6,11 +6,13 @@
 ;; Must follow Semver rules: https://semver.org/
 ;; NOTE: Versioning was added as of `2.0.0`
 ;; NOTE: Contract should be deployed with name matching version here
-(define-constant VERSION_MAJOR 2)
-(define-constant VERSION_MINOR 0)
-(define-constant VERSION_PATCH 0)
-(define-constant VERSION_PRERELEASE "")
-(define-constant VERSION_METADATA "")
+(define-constant VERSION {
+    major: 2,
+    minor: 0,
+    patch: 0,
+    prerelease: "",
+    metadata: ""
+})
 
 ;; Error codes
 (define-constant ERR_BLOCK_ALREADY_COMMITTED 1)
@@ -57,13 +59,7 @@
 ;; Get the version of this contract
 ;; Returns a tuple containing the 5 Semver fields: major, minor, patch, prerelease, and metadata
 (define-read-only (get-version)
-    {
-        major: VERSION_MAJOR,
-        minor: VERSION_MINOR,
-        patch: VERSION_PATCH,
-        prerelease: VERSION_PRERELEASE,
-        metadata: VERSION_PRERELEASE
-    }
+    VERSION
 )
 
 ;; Update the miner for this contract.

--- a/core-contracts/contracts/subnet.clar
+++ b/core-contracts/contracts/subnet.clar
@@ -2,6 +2,16 @@
 
 (define-constant CONTRACT_ADDRESS (as-contract tx-sender))
 
+;; Versioning of this contract
+;; Must follow Semver rules: https://semver.org/
+;; NOTE: Versioning was added as of `2.0.0`
+;; NOTE: Contract should be deployed with name matching version here
+(define-constant VERSION_MAJOR 2)
+(define-constant VERSION_MINOR 0)
+(define-constant VERSION_PATCH 0)
+(define-constant VERSION_PRERELEASE "")
+(define-constant VERSION_METADATA "")
+
 ;; Error codes
 (define-constant ERR_BLOCK_ALREADY_COMMITTED 1)
 (define-constant ERR_INVALID_MINER 2)
@@ -43,6 +53,18 @@
 (use-trait nft-trait 'SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.nft-trait.nft-trait)
 (use-trait ft-trait 'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard.sip-010-trait)
 (use-trait mint-from-subnet-trait .subnet-traits.mint-from-subnet-trait)
+
+;; Get the version of this contract
+;; Returns a tuple containing the 5 Semver fields: major, minor, patch, prerelease, and metadata
+(define-read-only (get-version)
+    {
+        major: VERSION_MAJOR,
+        minor: VERSION_MINOR,
+        patch: VERSION_PATCH,
+        prerelease: VERSION_PRERELEASE,
+        metadata: VERSION_PRERELEASE
+    }
+)
 
 ;; Update the miner for this contract.
 (define-public (update-miner (new-miner principal))

--- a/testnet/stacks-node/src/burnchains/mod.rs
+++ b/testnet/stacks-node/src/burnchains/mod.rs
@@ -41,6 +41,8 @@ mod tests;
 #[derive(Debug)]
 pub enum Error {
     UnsupportedBurnchain(String),
+    /// Problem with contract deployed on burnchain
+    UnsupportedBurnchainContract(String),
     CoordinatorClosed,
     IndexerError(burnchains::Error),
     RPCError(String),
@@ -51,12 +53,15 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Error::UnsupportedBurnchain(ref chain_name) => {
-                write!(f, "Burnchain is not supported: {:?}", chain_name)
+                write!(f, "Burnchain is not supported: {chain_name:?}")
+            }
+            Error::UnsupportedBurnchainContract(ref msg) => {
+                write!(f, "Burnchain contract is not supported: {msg}")
             }
             Error::CoordinatorClosed => write!(f, "ChainsCoordinator closed"),
-            Error::IndexerError(ref e) => write!(f, "Indexer error: {:?}", e),
-            Error::RPCError(ref e) => write!(f, "ControllerError(RPCError: {})", e),
-            Error::BadCommitment(ref e) => write!(f, "ControllerError(BadCommitment: {}))", e),
+            Error::IndexerError(ref e) => write!(f, "Indexer error: {e:?}"),
+            Error::RPCError(ref e) => write!(f, "ControllerError(RPCError: {e})"),
+            Error::BadCommitment(ref e) => write!(f, "ControllerError(BadCommitment: {e}))"),
         }
     }
 }


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/blockstack/stacks-blockchain/blob/master/sip/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

Add Semver versioning to `subnet.clar` L1 contract. Also, check version of `subnet.clar` from application and `multi-miner.clar`

### Applicable issues
- fixes #269

### Additional info (benefits, drawbacks, caveats)

- In `get_l1_contract_version()`, I used an arbitrary address I pulled from test code for `sender`. Since this call is to a read-only function, I don't think it matters what is used here
- This calls `get_l1_contract_version()` every time that `submit_commit()` is called to submit a block. Maybe this only has to be done once and cache the result?

### Checklist
- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
