### PR TITLE
fix: Should fix failures reading subnet contract version

### DIFF
--- a/core-contracts/contracts/multi-miner.clar
+++ b/core-contracts/contracts/multi-miner.clar
@@ -22,9 +22,9 @@
 
 ;; Minimun version of subnet contract required
 (define-constant SUBNET_CONTRACT_VERSION_MIN {
-    major: 2,
-    minor: 0,
-    patch: 0,
+    major: u2,
+    minor: u0,
+    patch: u0,
 })
 
 ;; Return error if subnet contract version not supported

--- a/core-contracts/contracts/subnet.clar
+++ b/core-contracts/contracts/subnet.clar
@@ -7,11 +7,11 @@
 ;; NOTE: Versioning was added as of `2.0.0`
 ;; NOTE: Contract should be deployed with name matching version here
 (define-constant VERSION {
-    major: 2,
-    minor: 0,
-    patch: 0,
-    prerelease: "",
-    metadata: ""
+    major: u2,
+    minor: u0,
+    patch: u0,
+    prerelease: none,
+    metadata: none
 })
 
 ;; Error codes


### PR DESCRIPTION
### Description
Properly deserialize response from call to read-only function `get-version` in `subnet.clar`

### Applicable issues
- fixes #276

### Additional info (benefits, drawbacks, caveats)
This is somewhat messy, and contains some `unwrap()`s and `panic!()`s when things don't go as expected (although I don't really expect them to ever be triggered). We are trying to get this out ASAP, so I'll clean up later.

### Checklist
- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
