### PR TITLE
ci: Update subnet contract version in Clarinet tests

### DIFF
--- a/core-contracts/Clarinet.toml
+++ b/core-contracts/Clarinet.toml
@@ -41,7 +41,7 @@ path = 'contracts/helper/simple-nft-no-mint.clar'
 clarity_version = 2
 epoch = 2.1
 
-[contracts.subnet]
+[contracts.subnet-v2-0-0]
 path = 'contracts/subnet.clar'
 clarity_version = 2
 epoch = 2.1
@@ -51,7 +51,7 @@ path = 'contracts/helper/test-helpers.clar'
 clarity_version = 2
 epoch = 2.1
 
-[contracts.subnet-traits]
+[contracts.subnet-traits-v1]
 path = 'contracts/helper/subnet-traits.clar'
 clarity_version = 2
 epoch = 2.1

--- a/core-contracts/contracts/helper/simple-ft.clar
+++ b/core-contracts/contracts/helper/simple-ft.clar
@@ -1,7 +1,7 @@
 (define-constant ERR_NOT_AUTHORIZED (err u1001))
 
 (impl-trait .sip-traits.ft-trait)
-(impl-trait .subnet-traits.mint-from-subnet-trait)
+(impl-trait .subnet-traits-v1.mint-from-subnet-trait)
 
 (define-fungible-token ft-token)
 

--- a/core-contracts/contracts/helper/simple-nft.clar
+++ b/core-contracts/contracts/helper/simple-nft.clar
@@ -4,7 +4,7 @@
 (define-constant ERR_NOT_AUTHORIZED (err u1001))
 
 (impl-trait .sip-traits.nft-trait)
-(impl-trait .subnet-traits.mint-from-subnet-trait)
+(impl-trait .subnet-traits-v1.mint-from-subnet-trait)
 
 (define-data-var lastId uint u0)
 (define-map CFG_BASE_URI bool (string-ascii 256))

--- a/core-contracts/tests/subnets/multiminer_test.ts
+++ b/core-contracts/tests/subnets/multiminer_test.ts
@@ -83,7 +83,7 @@ Clarinet.test({
     //  and set alice and signatory as miners in the multi-miner contract
     let initialize = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        "subnet-v2-0-0",
         "update-miner",
         [types.principal(multi_miner_contract)],
         deployer.address
@@ -251,7 +251,7 @@ Clarinet.test({
     //  and set signatory1 and signatory2 as miners in the multi-miner contract
     let initialize = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        "subnet-v2-0-0",
         "update-miner",
         [types.principal(multi_miner_contract)],
         deployer.address

--- a/core-contracts/tests/subnets/subnet_test.ts
+++ b/core-contracts/tests/subnets/subnet_test.ts
@@ -15,6 +15,8 @@ function fromHex(input: string) {
   return decHex(hexBytes);
 }
 
+const SUBNET_CONTRACT = "subnet-v2-0-0";
+
 Clarinet.test({
   name: "Unit test the withdrawal leaf hash calculations using test vectors",
   fn(
@@ -28,7 +30,7 @@ Clarinet.test({
     const recipient = "ST18F1AHKW194BWQ3CEFDPWVRARA79RBGFEWSDQR8";
     const leaf_hash_1 = chain
       .callReadOnlyFn(
-        "subnet",
+        SUBNET_CONTRACT,
         "leaf-hash-withdraw-stx",
         [
           types.uint(1),
@@ -49,7 +51,7 @@ Clarinet.test({
 
     const leaf_hash_2 = chain
       .callReadOnlyFn(
-        "subnet",
+        SUBNET_CONTRACT,
         "leaf-hash-withdraw-ft",
         [
           types.principal(ft_contract),
@@ -68,7 +70,7 @@ Clarinet.test({
 
     const leaf_hash_3 = chain
       .callReadOnlyFn(
-        "subnet",
+        SUBNET_CONTRACT,
         "leaf-hash-withdraw-nft",
         [
           types.principal(nft_contract),
@@ -104,14 +106,14 @@ Clarinet.test({
     let block = chain.mineBlock([
       // set alice as a miner
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "update-miner",
         [types.principal(alice.address)],
         deployer.address
       ),
       // Try to set alice as a miner again, should fail
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "update-miner",
         [types.principal(alice.address)],
         deployer.address
@@ -129,7 +131,7 @@ Clarinet.test({
     block = chain.mineBlock([
       // Successfully commit block at height 0 with alice.
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "commit-block",
         [
           types.buff(new Uint8Array([0, 1, 1, 1, 1])),
@@ -141,7 +143,7 @@ Clarinet.test({
       ),
       // Try and fail to commit a different block, but again at height 0.
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "commit-block",
         [
           types.buff(new Uint8Array([0, 2, 2, 2, 2])),
@@ -166,7 +168,7 @@ Clarinet.test({
     block = chain.mineBlock([
       // Try and fail to commit a block at height 1 with an invalid miner.
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "commit-block",
         [
           types.buff(new Uint8Array([0, 2, 2, 2, 2])),
@@ -178,7 +180,7 @@ Clarinet.test({
       ),
       // Try and fail to commit a block to non-existent `target-chain-tip`
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "commit-block",
         [
           types.buff(new Uint8Array([0, 2, 2, 2, 1])),
@@ -201,7 +203,7 @@ Clarinet.test({
       .toString();
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "commit-block",
         [
           types.buff(new Uint8Array([0, 2, 2, 2, 2])),
@@ -219,7 +221,7 @@ Clarinet.test({
 });
 
 Clarinet.test({
-  name: "Ensure that user can register and setup assets ",
+  name: "Ensure that user can register and setup assets",
   fn(
     chain: Chain,
     accounts: Map<string, Account>,
@@ -252,7 +254,7 @@ Clarinet.test({
     // set alice as a miner
     let block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "update-miner",
         [types.principal(alice.address)],
         deployer.address
@@ -263,7 +265,7 @@ Clarinet.test({
     // Invalid miner can't register contracts
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "register-new-ft-contract",
         [
           types.principal(simple_ft_contract.contract_id),
@@ -278,7 +280,7 @@ Clarinet.test({
     // Deployer can set up allowed assets
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "register-new-ft-contract",
         [
           types.principal(simple_ft_contract.contract_id),
@@ -287,7 +289,7 @@ Clarinet.test({
         deployer.address
       ),
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "register-new-nft-contract",
         [
           types.principal(simple_nft_contract.contract_id),
@@ -296,7 +298,7 @@ Clarinet.test({
         deployer.address
       ),
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "register-new-nft-contract",
         [
           types.principal(simple_nft_no_mint_contract.contract_id),
@@ -312,7 +314,7 @@ Clarinet.test({
     // Deployer should be able to register a new allowed NFT asset
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "register-new-nft-contract",
         [
           types.principal(second_nft_contract.contract_id),
@@ -326,7 +328,7 @@ Clarinet.test({
     // Deployer should be not able to register a previously allowed NFT asset
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "register-new-nft-contract",
         [
           types.principal(second_nft_contract.contract_id),
@@ -341,7 +343,7 @@ Clarinet.test({
     // Deployer should be able to register a new allowed FT asset
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "register-new-ft-contract",
         [
           types.principal(second_ft_contract.contract_id),
@@ -355,7 +357,7 @@ Clarinet.test({
     // Deployer should be not able to register a previously allowed FT asset
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "register-new-ft-contract",
         [
           types.principal(second_ft_contract.contract_id),
@@ -388,7 +390,7 @@ Clarinet.test({
     // set alice as a miner
     let block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "update-miner",
         [types.principal(alice.address)],
         deployer.address
@@ -401,7 +403,7 @@ Clarinet.test({
       "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.simple-nft"
     )!;
     const subnet_contract = contracts.get(
-      "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.subnet"
+      `ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.${SUBNET_CONTRACT}`
     )!;
 
     // User should be able to mint an NFT
@@ -422,7 +424,7 @@ Clarinet.test({
     // User should not be able to deposit NFT asset before miner allows the asset
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "deposit-nft-asset",
         [
           types.principal(nft_contract.contract_id),
@@ -438,7 +440,7 @@ Clarinet.test({
     // Invalid miner can't register contracts
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "register-new-nft-contract",
         [
           types.principal(nft_contract.contract_id),
@@ -454,7 +456,7 @@ Clarinet.test({
     block = chain.mineBlock([
       // Register contract
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "register-new-nft-contract",
         [
           types.principal(nft_contract.contract_id),
@@ -468,7 +470,7 @@ Clarinet.test({
     // User should be able to deposit NFT asset
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "deposit-nft-asset",
         [
           types.principal(nft_contract.contract_id),
@@ -489,7 +491,7 @@ Clarinet.test({
     // User should not be able to deposit an NFT asset they don't own
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "deposit-nft-asset",
         [
           types.principal(nft_contract.contract_id),
@@ -521,7 +523,7 @@ Clarinet.test({
     block = chain.mineBlock([
       // Successfully commit block at height 0 with alice.
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "commit-block",
         [
           types.buff(new Uint8Array([0, 1, 1, 1, 1])),
@@ -539,7 +541,7 @@ Clarinet.test({
     // Miner should be able to withdraw NFT asset for user
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-nft-asset",
         [
           types.principal(nft_contract.contract_id),
@@ -570,7 +572,7 @@ Clarinet.test({
     // Miner should not be able to withdraw NFT asset a second time
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-nft-asset",
         [
           types.principal(nft_contract.contract_id),
@@ -615,7 +617,7 @@ Clarinet.test({
     // set alice as a miner
     let block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "update-miner",
         [types.principal(alice.address)],
         deployer.address
@@ -628,7 +630,7 @@ Clarinet.test({
       "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.simple-nft"
     )!;
     const subnet_contract = contracts.get(
-      "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.subnet"
+      `ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.${SUBNET_CONTRACT}`
     )!;
 
     // User should be able to mint an NFT
@@ -650,7 +652,7 @@ Clarinet.test({
     block = chain.mineBlock([
       // Register contract
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "register-new-nft-contract",
         [
           types.principal(nft_contract.contract_id),
@@ -664,7 +666,7 @@ Clarinet.test({
     // User should be able to deposit NFT asset
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "deposit-nft-asset",
         [
           types.principal(nft_contract.contract_id),
@@ -711,7 +713,7 @@ Clarinet.test({
     block = chain.mineBlock([
       // Successfully commit block at height 0 with alice.
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "commit-block",
         [
           types.buff(new Uint8Array([0, 1, 1, 1, 1])),
@@ -730,7 +732,7 @@ Clarinet.test({
     block = chain.mineBlock([
       // Invalid root hash
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-nft-asset",
         [
           types.principal(nft_contract.contract_id),
@@ -752,7 +754,7 @@ Clarinet.test({
       ),
       // Invalid leaf hash
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-nft-asset",
         [
           types.principal(nft_contract.contract_id),
@@ -774,7 +776,7 @@ Clarinet.test({
       ),
       // Invalid sibling hashes
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-nft-asset",
         [
           types.principal(nft_contract.contract_id),
@@ -796,7 +798,7 @@ Clarinet.test({
       ),
       // Invalid ID
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-nft-asset",
         [
           types.principal(nft_contract.contract_id),
@@ -818,7 +820,7 @@ Clarinet.test({
       ),
       // Invalid recipient
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-nft-asset",
         [
           types.principal(nft_contract.contract_id),
@@ -840,7 +842,7 @@ Clarinet.test({
       ),
       // Invalid block height
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-nft-asset",
         [
           types.principal(nft_contract.contract_id),
@@ -862,7 +864,7 @@ Clarinet.test({
       ),
       // Invalid withdrawal ID
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-nft-asset",
         [
           types.principal(nft_contract.contract_id),
@@ -901,7 +903,7 @@ Clarinet.test({
     // Miner should be able to withdraw NFT asset for user
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-nft-asset",
         [
           types.principal(nft_contract.contract_id),
@@ -955,7 +957,7 @@ Clarinet.test({
     // set alice as a miner
     let block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "update-miner",
         [types.principal(alice.address)],
         deployer.address
@@ -988,7 +990,7 @@ Clarinet.test({
     // User should not be able to deposit FT assets if they are not allowed
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "deposit-ft-asset",
         [
           types.principal(ft_contract.contract_id),
@@ -1005,7 +1007,7 @@ Clarinet.test({
     // Invalid miner can't register new contracts
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "register-new-ft-contract",
         [
           types.principal(ft_contract.contract_id),
@@ -1020,7 +1022,7 @@ Clarinet.test({
     // Deployer sets up allowed assets
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "register-new-ft-contract",
         [
           types.principal(ft_contract.contract_id),
@@ -1034,7 +1036,7 @@ Clarinet.test({
     // User should not be able to deposit a larger quantity than they own
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "deposit-ft-asset",
         [
           types.principal(ft_contract.contract_id),
@@ -1051,7 +1053,7 @@ Clarinet.test({
     // User should be able to deposit FT asset
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "deposit-ft-asset",
         [
           types.principal(ft_contract.contract_id),
@@ -1067,7 +1069,7 @@ Clarinet.test({
     // User should not be able to deposit an FT asset they don't own
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "deposit-ft-asset",
         [
           types.principal(ft_contract.contract_id),
@@ -1100,7 +1102,7 @@ Clarinet.test({
     block = chain.mineBlock([
       // Successfully commit block at height 0 with alice.
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "commit-block",
         [
           types.buff(new Uint8Array([0, 1, 1, 1, 1])),
@@ -1118,7 +1120,7 @@ Clarinet.test({
     // Miner should be able to withdraw FT asset for user
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-ft-asset",
         [
           types.principal(ft_contract.contract_id),
@@ -1150,7 +1152,7 @@ Clarinet.test({
     // Miner should not be able to withdraw FT asset a second time
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-ft-asset",
         [
           types.principal(ft_contract.contract_id),
@@ -1200,7 +1202,7 @@ Clarinet.test({
     // set alice as a miner
     let block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "update-miner",
         [types.principal(alice.address)],
         deployer.address
@@ -1240,7 +1242,7 @@ Clarinet.test({
     // Deployer sets up allowed assets
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "register-new-ft-contract",
         [
           types.principal(ft_contract.contract_id),
@@ -1254,7 +1256,7 @@ Clarinet.test({
     // User should be able to deposit FT asset
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "deposit-ft-asset",
         [
           types.principal(ft_contract.contract_id),
@@ -1296,7 +1298,7 @@ Clarinet.test({
     block = chain.mineBlock([
       // Successfully commit block at height 0 with alice.
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "commit-block",
         [
           types.buff(new Uint8Array([0, 1, 1, 1, 1])),
@@ -1315,7 +1317,7 @@ Clarinet.test({
     block = chain.mineBlock([
       // Invalid root hash
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-ft-asset",
         [
           types.principal(ft_contract.contract_id),
@@ -1338,7 +1340,7 @@ Clarinet.test({
       ),
       // Invalid leaf hash
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-ft-asset",
         [
           types.principal(ft_contract.contract_id),
@@ -1361,7 +1363,7 @@ Clarinet.test({
       ),
       // Invalid sibling hashes
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-ft-asset",
         [
           types.principal(ft_contract.contract_id),
@@ -1384,7 +1386,7 @@ Clarinet.test({
       ),
       // Amount too large
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-ft-asset",
         [
           types.principal(ft_contract.contract_id),
@@ -1407,7 +1409,7 @@ Clarinet.test({
       ),
       // Invalid recipient
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-ft-asset",
         [
           types.principal(ft_contract.contract_id),
@@ -1430,7 +1432,7 @@ Clarinet.test({
       ),
       // Invalid block height
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-ft-asset",
         [
           types.principal(ft_contract.contract_id),
@@ -1453,7 +1455,7 @@ Clarinet.test({
       ),
       // Invalid withdrawal ID
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-ft-asset",
         [
           types.principal(ft_contract.contract_id),
@@ -1493,7 +1495,7 @@ Clarinet.test({
     // Miner should be able to withdraw FT asset for user
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-ft-asset",
         [
           types.principal(ft_contract.contract_id),
@@ -1546,7 +1548,7 @@ Clarinet.test({
     // set alice as a miner
     let block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "update-miner",
         [types.principal(alice.address)],
         deployer.address
@@ -1573,7 +1575,7 @@ Clarinet.test({
     // Deployer sets up allowed assets
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "register-new-ft-contract",
         [
           types.principal(ft_contract.contract_id),
@@ -1587,7 +1589,7 @@ Clarinet.test({
     // User should be able to deposit FT asset
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "deposit-ft-asset",
         [
           types.principal(ft_contract.contract_id),
@@ -1624,7 +1626,7 @@ Clarinet.test({
     block = chain.mineBlock([
       // Successfully commit block at height 0 with alice.
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "commit-block",
         [
           types.buff(new Uint8Array([0, 1, 1, 1, 1])),
@@ -1642,7 +1644,7 @@ Clarinet.test({
     // Miner should be able to withdraw FT asset for user
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-ft-asset",
         [
           types.principal(ft_contract.contract_id),
@@ -1674,7 +1676,7 @@ Clarinet.test({
     // Miner should be not be able to withdraw FT asset with same hash
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-ft-asset",
         [
           types.principal(ft_contract.contract_id),
@@ -1703,7 +1705,7 @@ Clarinet.test({
     // This test works since the amount is checked before the leaf hash is checked
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-ft-asset",
         [
           types.principal(ft_contract.contract_id),
@@ -1759,7 +1761,7 @@ Clarinet.test({
     // set alice as a miner
     let block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "update-miner",
         [types.principal(alice.address)],
         deployer.address
@@ -1801,7 +1803,7 @@ Clarinet.test({
     // Deployer sets up allowed assets
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "register-new-ft-contract",
         [
           types.principal(ft_contract.contract_id),
@@ -1810,7 +1812,7 @@ Clarinet.test({
         deployer.address
       ),
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "register-new-nft-contract",
         [
           types.principal(nft_contract.contract_id),
@@ -1834,7 +1836,7 @@ Clarinet.test({
     // User should be able to deposit FT asset
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "deposit-ft-asset",
         [
           types.principal(ft_contract.contract_id),
@@ -1850,7 +1852,7 @@ Clarinet.test({
     // User should be able to deposit STX
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "deposit-stx",
         [types.uint(5), types.principal(charlie.address)],
         charlie.address
@@ -1861,7 +1863,7 @@ Clarinet.test({
     // User should be able to deposit NFT
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "deposit-nft-asset",
         [
           types.principal(nft_contract.contract_id),
@@ -1922,7 +1924,7 @@ Clarinet.test({
     block = chain.mineBlock([
       // Successfully commit block at height 0 with alice.
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "commit-block",
         [
           types.buff(new Uint8Array([0, 1, 1, 1, 1])),
@@ -1940,7 +1942,7 @@ Clarinet.test({
     // Miner should be able to withdraw FT asset
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-ft-asset",
         [
           types.principal(ft_contract.contract_id),
@@ -1972,7 +1974,7 @@ Clarinet.test({
 
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-stx",
         [
           types.uint(1),
@@ -2000,7 +2002,7 @@ Clarinet.test({
     // Miner should be able to withdraw NFT asset
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-nft-asset",
         [
           types.principal(nft_contract.contract_id),
@@ -2043,7 +2045,7 @@ Clarinet.test({
     // For safety, check that miner can't withdraw FT asset a second time with same key
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-ft-asset",
         [
           types.principal(ft_contract.contract_id),
@@ -2075,7 +2077,7 @@ Clarinet.test({
     // For safety, check that miner can't withdraw STX asset a second time with same key
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-stx",
         [
           types.uint(1),
@@ -2104,7 +2106,7 @@ Clarinet.test({
     // For safety, check that miner can't withdraw NFT asset a second time with same key
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-nft-asset",
         [
           types.principal(nft_contract.contract_id),
@@ -2158,7 +2160,7 @@ Clarinet.test({
     // set alice as a miner
     let block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "update-miner",
         [types.principal(alice.address)],
         deployer.address
@@ -2169,7 +2171,7 @@ Clarinet.test({
     // Deployer sets up allowed assets
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "register-new-nft-contract",
         [
           types.principal(nft_contract.contract_id),
@@ -2214,7 +2216,7 @@ Clarinet.test({
     block = chain.mineBlock([
       // Successfully commit block at height 0 with alice.
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "commit-block",
         [
           types.buff(new Uint8Array([0, 1, 1, 1, 1])),
@@ -2232,7 +2234,7 @@ Clarinet.test({
     // Miner should be not able to withdraw NFT asset since it already exists on the L1
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-nft-asset",
         [
           types.principal(nft_contract.contract_id),
@@ -2280,7 +2282,7 @@ Clarinet.test({
     // set alice as a miner
     let block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "update-miner",
         [types.principal(alice.address)],
         deployer.address
@@ -2291,7 +2293,7 @@ Clarinet.test({
     // Deployer sets up allowed assets
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "register-new-nft-contract",
         [
           types.principal(nft_contract.contract_id),
@@ -2324,7 +2326,7 @@ Clarinet.test({
     block = chain.mineBlock([
       // Successfully commit block at height 0 with alice.
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "commit-block",
         [
           types.buff(new Uint8Array([0, 1, 1, 1, 1])),
@@ -2342,7 +2344,7 @@ Clarinet.test({
     // Miner should be able to withdraw NFT asset
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-nft-asset",
         [
           types.principal(nft_contract.contract_id),
@@ -2372,7 +2374,7 @@ Clarinet.test({
     // Miner should not be able to withdraw NFT asset a second time
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-nft-asset",
         [
           types.principal(nft_contract.contract_id),
@@ -2414,7 +2416,7 @@ Clarinet.test({
 
     chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "update-miner",
         [types.principal(miner.address)],
         deployer.address
@@ -2424,7 +2426,7 @@ Clarinet.test({
     // Deployer sets up allowed assets
     let block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "register-new-nft-contract",
         [
           types.principal(nft_contract.contract_id),
@@ -2458,7 +2460,7 @@ Clarinet.test({
     block = chain.mineBlock([
       // Successfully commit block at height 0.
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "commit-block",
         [
           types.buff(new Uint8Array([0, 1, 1, 1, 1])),
@@ -2476,7 +2478,7 @@ Clarinet.test({
     // Miner should *not* be able to withdraw NFT asset because the contract doesn't own it.
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-nft-asset",
         [
           types.principal(nft_contract.contract_id),
@@ -2519,7 +2521,7 @@ Clarinet.test({
 
     chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "update-miner",
         [types.principal(miner.address)],
         deployer.address
@@ -2544,7 +2546,7 @@ Clarinet.test({
     // Deployer sets up allowed assets
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "register-new-nft-contract",
         [
           types.principal(nft_contract.contract_id),
@@ -2558,7 +2560,7 @@ Clarinet.test({
     // User should be able to deposit NFT asset
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "deposit-nft-asset",
         [
           types.principal(nft_contract.contract_id),
@@ -2593,7 +2595,7 @@ Clarinet.test({
     block = chain.mineBlock([
       // Successfully commit block at height 0.
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "commit-block",
         [
           types.buff(new Uint8Array([0, 1, 1, 1, 1])),
@@ -2611,7 +2613,7 @@ Clarinet.test({
     // Miner should be able to withdraw NFT asset to original user.
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-nft-asset",
         [
           types.principal(nft_contract.contract_id),
@@ -2662,7 +2664,7 @@ Clarinet.test({
 
     chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "update-miner",
         [types.principal(miner.address)],
         deployer.address
@@ -2693,7 +2695,7 @@ Clarinet.test({
     // Deployer sets up allowed assets
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "register-new-nft-contract",
         [
           types.principal(nft_contract.contract_id),
@@ -2707,7 +2709,7 @@ Clarinet.test({
     // User should be able to deposit NFT asset
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "deposit-nft-asset",
         [
           types.principal(nft_contract.contract_id),
@@ -2745,7 +2747,7 @@ Clarinet.test({
     block = chain.mineBlock([
       // Successfully commit block at height 0.
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "commit-block",
         [
           types.buff(new Uint8Array([0, 1, 1, 1, 1])),
@@ -2763,7 +2765,7 @@ Clarinet.test({
     // Miner should be able to withdraw NFT asset to other_user.
     block = chain.mineBlock([
       Tx.contractCall(
-        "subnet",
+        SUBNET_CONTRACT,
         "withdraw-nft-asset",
         [
           types.principal(nft_contract.contract_id),


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/blockstack/stacks-blockchain/blob/master/sip/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

CI was failing because of the addition of subnet contract versioning. This PR adds the subnet contract version in Clarinet tests

### Applicable issues
- fixes #283 

### Additional info (benefits, drawbacks, caveats)

This required changing quite a bit of code. If anyone can think of a better way to do this I'll cancel the PR

### Checklist
- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
