### PR TITLE
ci: Fix Docker login step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,19 +178,19 @@ jobs:
   build-publish:
     runs-on: ubuntu-latest
     steps:
-      # Debian tag will be "<TAG> if a tag was passed in, otherwise "<BRANCH>". If the BRANCH is master, will result in "latest"
+      # Docker tag will be "<TAG> if a tag was passed in, otherwise "<BRANCH>". If the BRANCH is master, will result in "latest"
       -
-        name: Determine Debian Tag
+        name: Determine Docker Tag
         run: |
           if [[ -z ${TAG} ]]; then
               REF=$(echo ${GITHUB_REF#refs/*/} | tr / -)
               if [[ "${REF}" == "master" ]]; then
-                  echo "DEBIAN_TAG=latest" >> $GITHUB_ENV
+                  echo "DOCKER_TAG=latest" >> $GITHUB_ENV
               else
-                  echo "DEBIAN_TAG=${REF}" >> $GITHUB_ENV
+                  echo "DOCKER_TAG=${REF}" >> $GITHUB_ENV
               fi
           else
-              echo "DEBIAN_TAG=${TAG}" >> $GITHUB_ENV
+              echo "DOCKER_TAG=${TAG}" >> $GITHUB_ENV
           fi
         env:
           TAG: ${{ github.event.inputs.tag }}
@@ -206,15 +206,15 @@ jobs:
       -
         name: Login to Docker Hub
         uses: docker/login-action@v2
-        if: env.DOCKER_PUSH == true
+        if: env.DOCKER_PUSH == 'true'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
       -
         name: Build/Tag/Push Image
         uses: docker/build-push-action@v4
         with:
-          tags: ${{ env.DEBIAN_TAG }}
+          tags: hirosystems/stacks-subnets:${{ env.DOCKER_TAG }}
           build-args: SUBNET_NODE_VERSION=${{ github.event.inputs.tag || env.GITHUB_SHA_SHORT }},GIT_BRANCH=${{ env.GITHUB_REF_SHORT }},GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
           # Only push if ( we have DockerHub credentials and ((a tag was passed in) or (we're building a non-master branch))
           push: ${{ env.DOCKER_PUSH }}


### PR DESCRIPTION
### Description

This now logs in, builds, and pushes the Docker image in the main repository: https://github.com/hirosystems/stacks-subnets/actions/runs/5282021630/jobs/9556390408

- Fix checking of `DOCKER_PUSH` env variable so that Docker login step is not skipped
- Fix Docker tags
