### PR TITLE
Ci/improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,14 @@
 name: CI
 
 # Only run when:
-#   - PRs are opened against the master branch
-#   - the workflow is started from the UI (an optional tag can be passed in via parameter)
-#     - If the optional tag parameter is passed in, a new tag will be generated based off the selected branch
+#   - PRs are opened
+#   - the workflow is started from the UI
 on:
   pull_request:
   workflow_dispatch:
-    inputs:
-      tag:
-        description: 'The tag to create (optional)'
-        required: false
 
 concurrency:
-  group: stacks-blockchain-${{ github.ref }}
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
   # Only cancel in progress if this is for a PR
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
@@ -22,7 +17,8 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
       - name: Run units tests (with coverage)
         env:
           DOCKER_BUILDKIT: 1
@@ -30,16 +26,19 @@ jobs:
         run: |
           rm .dockerignore
           docker build -o coverage-output -f ./.github/actions/bitcoin-int-tests/Dockerfile.code-cov .
-      - uses: codecov/codecov-action@v2
+
+      - uses: codecov/codecov-action@v3
         with:
           files: ./coverage-output/lcov.info
           name: unit_tests
           fail_ci_if_error: false
+
   # Build subnets image for tests that require stacks-node
   build-layer-1-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
       - name: Build layer-1 integration testing image
         env:
           DOCKER_BUILDKIT: 1
@@ -47,23 +46,28 @@ jobs:
         run: |
           rm .dockerignore
           docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.generic.stacks-node -t subnet-node:integrations .
+
       - name: Export docker image as tarball
         run: docker save -o integration-image.tar subnet-node:integrations
+
       - name: Upload built docker image
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: integration-image.tar
           path: integration-image.tar
+
   compute-layer-1-tests:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
       - id: set-matrix
         run: |
           cargo test --workspace --bin=subnet-node -- l --list --format=terse | sed -e 's/: test//g' | jq -ncR '{"test-name": [inputs]}' > test_names.json
           echo "::set-output name=matrix::$(cat test_names.json)"
+
   # Run the tests that require stacks-node
   layer-1-tests:
     runs-on: ubuntu-latest
@@ -74,20 +78,24 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.compute-layer-1-tests.outputs.matrix)}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
       - name: Download docker image
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: integration-image.tar
+
       - name: Load docker image
         run: docker load -i integration-image.tar && rm integration-image.tar
+
       - name: Run layer 1 tests
         timeout-minutes: 30
         env:
           DOCKER_BUILDKIT: 1
           TEST_NAME: ${{ matrix.test-name }}
         run: docker build -o coverage-output --build-arg test_name=${{ matrix.test-name }} -f ./.github/actions/bitcoin-int-tests/Dockerfile.stacks-node .
-      - uses: codecov/codecov-action@v2
+
+      - uses: codecov/codecov-action@v3
         with:
           files: ./coverage-output/lcov.info
           name: ${{ matrix.test-name }}
@@ -96,7 +104,8 @@ jobs:
   integration-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
       - name: Run units tests (with coverage)
         env:
           DOCKER_BUILDKIT: 1
@@ -104,23 +113,25 @@ jobs:
         run: |
           rm .dockerignore
           docker build -o coverage-output -f ./.github/actions/bitcoin-int-tests/Dockerfile.integrations .
-      - uses: codecov/codecov-action@v2
+
+      - uses: codecov/codecov-action@v3
         with:
           files: ./coverage-output/lcov.info
           name: integration_tests
           fail_ci_if_error: false
 
-
   open-api-validation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
       - name: Run units tests (with coverage)
         env:
           DOCKER_BUILDKIT: 1
         run: docker build -o dist/ -f .github/actions/open-api/Dockerfile.open-api-validate .
+
       - name: Upload bundled html
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: open-api-bundle
           path: |
@@ -130,91 +141,83 @@ jobs:
   rustfmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
       - name: Run rustfmt check
         env:
           DOCKER_BUILDKIT: 1
         run: docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.rustfmt .
-  build-clarinet-2_1:
+
+  clarinet-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - name: Execute unit tests
+        uses: docker://hirosystems/clarinet:1.7
         with:
-          repository: hirosystems/clarinet
-          ref: main
-          submodules: recursive
-      - name: Build Clarinet with 2.1
-        run: cargo build -p=clarinet-cli
-      - name: Upload Clarinet binary
-        uses: actions/upload-artifact@v2
-        with:
-          name: clarinet
-          path: ./target/debug/clarinet
-  clarinet-test:
-    runs-on: ubuntu-latest
-    needs: build-clarinet-2_1
-    steps:
-      - uses: actions/checkout@v2
-      - name: Download built Clarinet 2.1 artifact 
-        uses: actions/download-artifact@v2
-        with:
-          name: clarinet
-      - name: "Make Clarinet executable"
-        run: chmod +x ./clarinet
-      - name: "Execute Clarinet tests"
-        run: ./clarinet test --coverage --manifest-path=./core-contracts/Clarinet.toml --import-map=./core-contracts/import_map.json --allow-net
-      - name: "Export code coverage"
-        uses: codecov/codecov-action@v1
+          args: test --coverage --manifest-path=./core-contracts/Clarinet.toml --import-map=./core-contracts/import_map.json --allow-net
+
+      - name: Export code coverage
+        uses: codecov/codecov-action@v3
         with:
           files: ./coverage.lcov
           fail_ci_if_error: false
           verbose: true
 
-  # Build docker image, tag it with the git tag and `latest` if running on master branch, and publish under the following conditions
-  # Will publish if:
-  #   - a tag was passed into this workflow
-  #   - a tag was pushed up
-  #   - this workflow was invoked against a non-master branch (a Docker image tag with the name of the branch will be published)
+  # Creates a new release depending on git commit messages following conventional commits: https://www.conventionalcommits.org/en/v1.0.0/#summary
+  # Builds and publishes a new Docker image with appropriate tags
   build-publish:
     runs-on: ubuntu-latest
     steps:
-      # Docker tag will be "<TAG> if a tag was passed in, otherwise "<BRANCH>". If the BRANCH is master, will result in "latest"
-      -
-        name: Determine Docker Tag
-        run: |
-          if [[ -z ${TAG} ]]; then
-              REF=$(echo ${GITHUB_REF#refs/*/} | tr / -)
-              if [[ "${REF}" == "master" ]]; then
-                  echo "DOCKER_TAG=latest" >> $GITHUB_ENV
-              else
-                  echo "DOCKER_TAG=${REF}" >> $GITHUB_ENV
-              fi
-          else
-              echo "DOCKER_TAG=${TAG}" >> $GITHUB_ENV
-          fi
+      - uses: actions/checkout@v3
+
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v3
+        id: semantic
+        # Only run on non-PR events or only PRs that aren't from forks
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         env:
-          TAG: ${{ github.event.inputs.tag }}
-      -
-        name: Set Vars
-        run: |
-          echo "GITHUB_SHA_SHORT=${GITHUB_SHA::7}" >> $GITHUB_ENV
-          echo "GITHUB_REF_SHORT=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-          echo "DOCKER_PUSH=${{ (secrets.DOCKERHUB_USERNAME != '') && (secrets.DOCKERHUB_PASSWORD != '') && ((github.event.inputs.tag != '') || (github.ref != 'refs/heads/master')) }}" >> $GITHUB_ENV
-      -
-        name: Set up Docker Buildx
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+          SEMANTIC_RELEASE_PACKAGE: ${{ github.event.repository.name }}
+        with:
+          semantic_version: 19
+          extra_plugins: |
+            @semantic-release/changelog
+            @semantic-release/git
+            conventional-changelog-conventionalcommits
+
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      -
-        name: Login to Docker Hub
+
+      - name: Docker Meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            hirosystems/${{ github.event.repository.name }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}},value=${{ steps.semantic.outputs.new_release_version }},enable=${{ steps.semantic.outputs.new_release_version != '' }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.semantic.outputs.new_release_version }},enable=${{ steps.semantic.outputs.new_release_version != '' }}
+
+      - name: Login to Docker Hub
         uses: docker/login-action@v2
-        if: env.DOCKER_PUSH == 'true'
+        # Only run on non-PR events or only PRs that aren't from forks
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      -
-        name: Build/Tag/Push Image
+
+      - name: Build/Tag/Push Image
         uses: docker/build-push-action@v4
         with:
-          tags: hirosystems/stacks-subnets:${{ env.DOCKER_TAG }}
-          build-args: SUBNET_NODE_VERSION=${{ github.event.inputs.tag || env.GITHUB_SHA_SHORT }},GIT_BRANCH=${{ env.GITHUB_REF_SHORT }},GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
-          # Only push if ( we have DockerHub credentials and ((a tag was passed in) or (we're building a non-master branch))
-          push: ${{ env.DOCKER_PUSH }}
+          tags: ${{ steps.meta.outputs.tags }}
+          build-args: |
+            SUBNET_NODE_VERSION=${{ steps.semantic.outputs.new_release_published == 'true' && steps.semantic.outputs.new_release_version || github.sha }}
+            GIT_BRANCH=${{ github.ref_name }}
+            GIT_COMMIT=${{ github.sha }}
+          # Only push on non-PR events or only PRs that aren't from forks
+          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,6 @@ jobs:
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
           SEMANTIC_RELEASE_PACKAGE: ${{ github.event.repository.name }}
         with:
           semantic_version: 19

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,14 @@ name: CI
 #   - PRs are opened
 #   - the workflow is started from the UI
 on:
+  push:
+    branches:
+      - master
+    tags-ignore:
+      - '**'
+    paths-ignore:
+      - '**/CHANGELOG.md'
+      - '**/.releaserc'
   pull_request:
   workflow_dispatch:
 

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,8 @@
+plugins:
+  - - "@semantic-release/commit-analyzer"
+    - preset: conventionalcommits
+  - - "@semantic-release/release-notes-generator"
+    - preset: conventionalcommits
+  - "@semantic-release/github"
+  - "@semantic-release/changelog"
+  - "@semantic-release/git"


### PR DESCRIPTION
Closes https://github.com/hirosystems/devops/issues/1235

* Adds a semantic release step
    * Using the [Semantic Release](https://github.com/semantic-release/semantic-release) CLI, determines if a new release should be created, managing git tags, GitHub releases, changelogs, and Docker tags.
        * With this initial implementation, releases will only be generated off the `master` branch, but `beta` or `alpha` pre-releases can be generated similarly off other branches if desired.
        * Determines if a new release should be created by reading all of the git commit messages since the last detected release, and finding any that match the `fix:` or `feat:` prefix based on [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
* Updates all Github Actions versions
* Simplifies Clarinet tests by using the Clarinet Docker image instead of building the CLI locally