### PR TITLE
feat: Retry certain failed transactions against latest microblocks

### DIFF
--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -6371,66 +6371,64 @@ impl StacksChainState {
             )),
         };
 
-        match res {
-            Ok(x) => Ok(x),
-            Err(e) => match e {
-                MemPoolRejection::BadNonces(mismatch_error) => {
-                    // try again, but against the _unconfirmed_ chain tip, if we
-                    // (a) have one, and (b) the expected nonce is less than the given one.
-                    if self.unconfirmed_state.is_some()
-                        && mismatch_error.expected < mismatch_error.actual
-                    {
-                        debug!("Transaction {} is unminable in the confirmed chain tip due to nonce {} != {}; trying the unconfirmed chain tip",
-                            &tx.txid(), mismatch_error.expected, mismatch_error.actual);
-                        self.with_read_only_unconfirmed_clarity_tx(&NULL_BURN_STATE_DB, |conn| {
-                            StacksChainState::can_include_tx(conn, &conf, true, tx, tx_size)
-                        })
-                        .map_err(|_| {
-                            MemPoolRejection::NoSuchChainTip(
-                                current_consensus_hash.clone(),
-                                current_block.clone(),
-                            )
-                        })?
-                        .expect("BUG: do not have unconfirmed state, despite being Some(..)")
-                    } else {
-                        Err(MemPoolRejection::BadNonces(mismatch_error))
-                    }
-                }
-                // Error cases where retrying against `unconfirmed_state` may succeed
-                MemPoolRejection::FeeTooLow(_, _) |
-                MemPoolRejection::NotEnoughFunds(_, _) |
-                MemPoolRejection::NoSuchContract |
-                MemPoolRejection::NoSuchPublicFunction |
-                MemPoolRejection::PoisonMicroblocksDoNotConflict |
-                MemPoolRejection::InvalidMicroblocks |
-                MemPoolRejection::NoAnchorBlockWithPubkeyHash(_) |
-                MemPoolRejection::NoAnchorBlockWithPubkeyHashes(_) |
-                MemPoolRejection::NoSuchChainTip(_, _) |
-                MemPoolRejection::DBError(_) |
-                MemPoolRejection::EstimatorError(_) |
-                MemPoolRejection::Other(_) => {
-                    debug!("Retry transaction {} against unconfirmed state", tx.txid());
+        // For some error conditions, retry transaction
+        res.or_else(|e| match e {
+            MemPoolRejection::BadNonces(mismatch_error) => {
+                // try again, but against the _unconfirmed_ chain tip, if we
+                // (a) have one, and (b) the expected nonce is less than the given one.
+                if self.unconfirmed_state.is_some()
+                    && mismatch_error.expected < mismatch_error.actual
+                {
+                    debug!("Transaction {} is unminable in the confirmed chain tip due to nonce {} != {}; trying the unconfirmed chain tip",
+                        &tx.txid(), mismatch_error.expected, mismatch_error.actual);
                     self.with_read_only_unconfirmed_clarity_tx(&NULL_BURN_STATE_DB, |conn| {
                         StacksChainState::can_include_tx(conn, &conf, true, tx, tx_size)
                     })
-                    .map_err(|_| e)?
+                    .map_err(|_| {
+                        MemPoolRejection::NoSuchChainTip(
+                            current_consensus_hash.clone(),
+                            current_block.clone(),
+                        )
+                    })?
                     .expect("BUG: do not have unconfirmed state, despite being Some(..)")
+                } else {
+                    Err(MemPoolRejection::BadNonces(mismatch_error))
                 }
-                // Error cases where we should not retry against `unconfirmed_state`
-                MemPoolRejection::SerializationFailure(_) |
-                MemPoolRejection::DeserializationFailure(_) |
-                MemPoolRejection::FailedToValidate(_) |
-                MemPoolRejection::BadFunctionArgument(_) |
-                MemPoolRejection::ContractAlreadyExists(_) |
-                MemPoolRejection::BadAddressVersionByte |
-                MemPoolRejection::NoCoinbaseViaMempool |
-                MemPoolRejection::TooMuchChaining { .. } |
-                MemPoolRejection::ConflictingNonceInMempool |
-                MemPoolRejection::BadTransactionVersion |
-                MemPoolRejection::TransferAmountMustBePositive |
-                MemPoolRejection::TransferRecipientIsSender(_) => Err(e)
             }
-        }
+            // Error cases where retrying against `unconfirmed_state` may succeed
+            MemPoolRejection::FeeTooLow(_, _) |
+            MemPoolRejection::NotEnoughFunds(_, _) |
+            MemPoolRejection::NoSuchContract |
+            MemPoolRejection::PoisonMicroblocksDoNotConflict |
+            MemPoolRejection::InvalidMicroblocks |
+            MemPoolRejection::NoSuchChainTip(_, _) |
+            MemPoolRejection::DBError(_) |
+            MemPoolRejection::EstimatorError(_) |
+            MemPoolRejection::TooMuchChaining { .. } |
+            MemPoolRejection::Other(_) => {
+                debug!("Retrying transaction {} against unconfirmed state", tx.txid());
+                self.with_read_only_unconfirmed_clarity_tx(&NULL_BURN_STATE_DB, |conn| {
+                    StacksChainState::can_include_tx(conn, &conf, true, tx, tx_size)
+                })
+                .map_err(|_| e)?
+                .expect("BUG: do not have unconfirmed state, despite being Some(..)")
+            }
+            // Error cases where we should not retry against `unconfirmed_state`
+            MemPoolRejection::SerializationFailure(_) |
+            MemPoolRejection::DeserializationFailure(_) |
+            MemPoolRejection::FailedToValidate(_) |
+            MemPoolRejection::BadFunctionArgument(_) |
+            MemPoolRejection::ContractAlreadyExists(_) |
+            MemPoolRejection::NoSuchPublicFunction |
+            MemPoolRejection::NoAnchorBlockWithPubkeyHash(_) |
+            MemPoolRejection::NoAnchorBlockWithPubkeyHashes(_) |
+            MemPoolRejection::BadAddressVersionByte |
+            MemPoolRejection::NoCoinbaseViaMempool |
+            MemPoolRejection::ConflictingNonceInMempool |
+            MemPoolRejection::BadTransactionVersion |
+            MemPoolRejection::TransferAmountMustBePositive |
+            MemPoolRejection::TransferRecipientIsSender(_) => Err(e)
+        })
     }
 
     /// Given an outstanding clarity connection, can we append the tx to the chain state?

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -1885,7 +1885,7 @@ impl StacksChainState {
                 return None;
             }
             Err(e) => {
-                warn!("Failed to query for {}: {:?}", parent_tip, &e);
+                warn!("Failed to query for {parent_tip}: {e:?}");
                 return None;
             }
         }
@@ -1903,14 +1903,14 @@ impl StacksChainState {
     where
         F: FnOnce(&mut ClarityReadOnlyConnection) -> R,
     {
-        if let Some(ref unconfirmed) = self.unconfirmed_state.as_ref() {
+        if let Some(unconfirmed) = &self.unconfirmed_state {
             if !unconfirmed.is_readable() {
                 return Ok(None);
             }
         }
 
         let mut unconfirmed_state_opt = self.unconfirmed_state.take();
-        let res = if let Some(ref mut unconfirmed_state) = unconfirmed_state_opt {
+        let res = if let Some(unconfirmed_state) = unconfirmed_state_opt.as_mut() {
             let mut conn = unconfirmed_state
                 .clarity_inst
                 .read_only_connection_checked(

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -90,7 +90,7 @@ use crate::util_lib::db::table_exists;
 
 // maximum number of confirmations a transaction can have before it's garbage-collected
 pub const MEMPOOL_MAX_TRANSACTION_AGE: u64 = 256;
-pub const MAXIMUM_MEMPOOL_TX_CHAINING: u64 = 600;
+pub const MAXIMUM_MEMPOOL_TX_CHAINING: u64 = 25;
 
 // name of table for storing the counting bloom filter
 pub const BLOOM_COUNTER_TABLE: &'static str = "txid_bloom_counter";


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/blockstack/stacks-blockchain/blob/master/sip/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

Retry certain failed transactions against latest microblocks (`unconfirmed_state`)

### Applicable issues
- fixes #299

### Additional info (benefits, drawbacks, caveats)

Still need to write tests to confirm this behaves as expected. Due to time constraints, I'm going to merge this and create a new issue for the tests.

### Checklist
- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
