### PR TITLE
Fix exit status for CI job `compute-layer-1-tests` 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,9 @@ jobs:
         run: just process-templates
 
       - id: set-matrix
+        shell: bash
         run: |
-          cargo test --workspace --bin=subnet-node -- l --list --format=terse | sed -e 's/: test//g' | jq -ncR '{"test-name": [inputs]}' > test_names.json
+          set -o pipefail; cargo test --workspace --bin=subnet-node -- l --list --format=terse | sed -e 's/: test//g' | jq -ncR '{"test-name": [inputs]}' > test_names.json
           echo "::set-output name=matrix::$(cat test_names.json)"
 
   # Run the tests that require stacks-node


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/blockstack/stacks-blockchain/blob/master/sip/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

Add `set -o pipefail` to CI job `compute-layer-1-tests` so proper exit status is reported

### Applicable issues
- fixes #309