### PR TITLE
feat: API now responds with state from latest microblocks by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,13 @@ ARG GIT_COMMIT='No Commit Info'
 
 WORKDIR /src
 
-COPY --link . .
-
 RUN apt-get update && \
     apt-get install -y ruby-mustache && \
     rustup component add llvm-tools-preview && \
     cargo install just
+
+# Do after package install so we don't invalidate the cache
+COPY --link . .
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/src/target,sharing=private \

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -1939,7 +1939,7 @@ impl StacksChainState {
     where
         F: FnOnce(&mut ClarityReadOnlyConnection) -> R,
     {
-        let unconfirmed = if let Some(ref unconfirmed_state) = self.unconfirmed_state {
+        let unconfirmed = if let Some(unconfirmed_state) = &self.unconfirmed_state {
             *parent_tip == unconfirmed_state.unconfirmed_chain_tip
                 && unconfirmed_state.is_readable()
         } else {

--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -1772,15 +1772,17 @@ impl HttpRequestType {
 
                     if value == "latest" {
                         return TipRequest::UseLatestUnconfirmedTip;
+                    } else if value == "anchored" {
+                        return TipRequest::UseLatestAnchoredTip;
                     }
                     if let Ok(tip) = StacksBlockId::from_hex(&value) {
                         return TipRequest::SpecificTip(tip);
                     }
                 }
-                return TipRequest::UseLatestAnchoredTip;
+                return TipRequest::UseLatestUnconfirmedTip;
             }
             None => {
-                return TipRequest::UseLatestAnchoredTip;
+                return TipRequest::UseLatestUnconfirmedTip;
             }
         }
     }
@@ -2844,41 +2846,41 @@ impl HttpRequestType {
     }
 
     pub fn metadata(&self) -> &HttpRequestMetadata {
-        match *self {
-            HttpRequestType::GetInfo(ref md) => md,
-            HttpRequestType::GetNeighbors(ref md) => md,
-            HttpRequestType::GetHeaders(ref md, ..) => md,
-            HttpRequestType::GetBlock(ref md, _) => md,
-            HttpRequestType::GetMicroblocksIndexed(ref md, _) => md,
-            HttpRequestType::GetMicroblocksConfirmed(ref md, _) => md,
-            HttpRequestType::GetMicroblocksUnconfirmed(ref md, _, _) => md,
-            HttpRequestType::GetTransactionUnconfirmed(ref md, _) => md,
-            HttpRequestType::PostTransaction(ref md, _, _) => md,
-            HttpRequestType::PostBlock(ref md, ..) => md,
-            HttpRequestType::PostMicroblock(ref md, ..) => md,
-            HttpRequestType::GetAccount(ref md, ..) => md,
-            HttpRequestType::GetDataVar(ref md, ..) => md,
-            HttpRequestType::GetMapEntry(ref md, ..) => md,
-            HttpRequestType::GetTransferCost(ref md) => md,
-            HttpRequestType::GetContractABI(ref md, ..) => md,
-            HttpRequestType::GetContractSrc(ref md, ..) => md,
-            HttpRequestType::GetIsTraitImplemented(ref md, ..) => md,
-            HttpRequestType::CallReadOnlyFunction(ref md, ..) => md,
-            HttpRequestType::OptionsPreflight(ref md, ..) => md,
-            HttpRequestType::GetAttachmentsInv(ref md, ..) => md,
-            HttpRequestType::GetAttachment(ref md, ..) => md,
-            HttpRequestType::MemPoolQuery(ref md, ..) => md,
-            HttpRequestType::FeeRateEstimate(ref md, _, _) => md,
-            HttpRequestType::ClientError(ref md, ..) => md,
-            HttpRequestType::GetWithdrawalStx { ref metadata, .. } => metadata,
-            HttpRequestType::BlockProposal(ref metadata, ..) => metadata,
-            HttpRequestType::GetWithdrawalFt { ref metadata, .. } => metadata,
-            HttpRequestType::GetWithdrawalNft { ref metadata, .. } => metadata,
+        match self {
+            HttpRequestType::GetInfo(md) => md,
+            HttpRequestType::GetNeighbors(md) => md,
+            HttpRequestType::GetHeaders(md, ..) => md,
+            HttpRequestType::GetBlock(md, _) => md,
+            HttpRequestType::GetMicroblocksIndexed(md, _) => md,
+            HttpRequestType::GetMicroblocksConfirmed(md, _) => md,
+            HttpRequestType::GetMicroblocksUnconfirmed(md, _, _) => md,
+            HttpRequestType::GetTransactionUnconfirmed(md, _) => md,
+            HttpRequestType::PostTransaction(md, _, _) => md,
+            HttpRequestType::PostBlock(md, ..) => md,
+            HttpRequestType::PostMicroblock(md, ..) => md,
+            HttpRequestType::GetAccount(md, ..) => md,
+            HttpRequestType::GetDataVar(md, ..) => md,
+            HttpRequestType::GetMapEntry(md, ..) => md,
+            HttpRequestType::GetTransferCost(md) => md,
+            HttpRequestType::GetContractABI(md, ..) => md,
+            HttpRequestType::GetContractSrc(md, ..) => md,
+            HttpRequestType::GetIsTraitImplemented(md, ..) => md,
+            HttpRequestType::CallReadOnlyFunction(md, ..) => md,
+            HttpRequestType::OptionsPreflight(md, ..) => md,
+            HttpRequestType::GetAttachmentsInv(md, ..) => md,
+            HttpRequestType::GetAttachment(md, ..) => md,
+            HttpRequestType::MemPoolQuery(md, ..) => md,
+            HttpRequestType::FeeRateEstimate(md, _, _) => md,
+            HttpRequestType::ClientError(md, ..) => md,
+            HttpRequestType::GetWithdrawalStx { metadata, .. } => metadata,
+            HttpRequestType::BlockProposal(metadata, ..) => metadata,
+            HttpRequestType::GetWithdrawalFt { metadata, .. } => metadata,
+            HttpRequestType::GetWithdrawalNft { metadata, .. } => metadata,
         }
     }
 
     pub fn metadata_mut(&mut self) -> &mut HttpRequestMetadata {
-        match *self {
+        match self {
             HttpRequestType::GetInfo(ref mut md) => md,
             HttpRequestType::GetNeighbors(ref mut md) => md,
             HttpRequestType::GetHeaders(ref mut md, ..) => md,
@@ -3196,8 +3198,7 @@ impl HttpRequestType {
                         serde_json::to_writer(&mut request_body_bytes, &request_body).map_err(
                             |e| {
                                 net_error::SerializeError(format!(
-                                    "Failed to serialize read-only call to JSON: {:?}",
-                                    &e
+                                    "Failed to serialize read-only call to JSON: {e:?}"
                                 ))
                             },
                         )?;
@@ -3305,8 +3306,7 @@ impl HttpRequestType {
                 let mut request_body_bytes = vec![];
                 serde_json::to_writer(&mut request_body_bytes, &request_body).map_err(|e| {
                     net_error::SerializeError(format!(
-                        "Failed to serialize read-only call to JSON: {:?}",
-                        &e
+                        "Failed to serialize read-only call to JSON: {e:?}"
                     ))
                 })?;
 
@@ -4217,47 +4217,47 @@ impl HttpResponseType {
     }
 
     pub fn metadata(&self) -> &HttpResponseMetadata {
-        match *self {
-            HttpResponseType::PeerInfo(ref md, _) => md,
-            HttpResponseType::PoxInfo(ref md, _) => md,
-            HttpResponseType::Neighbors(ref md, _) => md,
-            HttpResponseType::HeaderStream(ref md) => md,
-            HttpResponseType::Headers(ref md, _) => md,
-            HttpResponseType::Block(ref md, _) => md,
-            HttpResponseType::BlockStream(ref md) => md,
-            HttpResponseType::Microblocks(ref md, _) => md,
-            HttpResponseType::MicroblockStream(ref md) => md,
-            HttpResponseType::TransactionID(ref md, _) => md,
-            HttpResponseType::StacksBlockAccepted(ref md, ..) => md,
-            HttpResponseType::MicroblockHash(ref md, _) => md,
-            HttpResponseType::TokenTransferCost(ref md, _) => md,
-            HttpResponseType::GetDataVar(ref md, _) => md,
-            HttpResponseType::GetMapEntry(ref md, _) => md,
-            HttpResponseType::GetAccount(ref md, _) => md,
-            HttpResponseType::GetContractABI(ref md, _) => md,
-            HttpResponseType::GetContractSrc(ref md, _) => md,
-            HttpResponseType::GetIsTraitImplemented(ref md, _) => md,
-            HttpResponseType::CallReadOnlyFunction(ref md, _) => md,
-            HttpResponseType::UnconfirmedTransaction(ref md, _) => md,
-            HttpResponseType::GetAttachment(ref md, _) => md,
-            HttpResponseType::GetAttachmentsInv(ref md, _) => md,
-            HttpResponseType::MemPoolTxStream(ref md) => md,
-            HttpResponseType::MemPoolTxs(ref md, ..) => md,
-            HttpResponseType::OptionsPreflight(ref md) => md,
-            HttpResponseType::TransactionFeeEstimation(ref md, _) => md,
-            HttpResponseType::GetWithdrawal(ref md, _) => md,
+        match self {
+            HttpResponseType::PeerInfo(md, _) => md,
+            HttpResponseType::PoxInfo(md, _) => md,
+            HttpResponseType::Neighbors(md, _) => md,
+            HttpResponseType::HeaderStream(md) => md,
+            HttpResponseType::Headers(md, _) => md,
+            HttpResponseType::Block(md, _) => md,
+            HttpResponseType::BlockStream(md) => md,
+            HttpResponseType::Microblocks(md, _) => md,
+            HttpResponseType::MicroblockStream(md) => md,
+            HttpResponseType::TransactionID(md, _) => md,
+            HttpResponseType::StacksBlockAccepted(md, ..) => md,
+            HttpResponseType::MicroblockHash(md, _) => md,
+            HttpResponseType::TokenTransferCost(md, _) => md,
+            HttpResponseType::GetDataVar(md, _) => md,
+            HttpResponseType::GetMapEntry(md, _) => md,
+            HttpResponseType::GetAccount(md, _) => md,
+            HttpResponseType::GetContractABI(md, _) => md,
+            HttpResponseType::GetContractSrc(md, _) => md,
+            HttpResponseType::GetIsTraitImplemented(md, _) => md,
+            HttpResponseType::CallReadOnlyFunction(md, _) => md,
+            HttpResponseType::UnconfirmedTransaction(md, _) => md,
+            HttpResponseType::GetAttachment(md, _) => md,
+            HttpResponseType::GetAttachmentsInv(md, _) => md,
+            HttpResponseType::MemPoolTxStream(md) => md,
+            HttpResponseType::MemPoolTxs(md, ..) => md,
+            HttpResponseType::OptionsPreflight(md) => md,
+            HttpResponseType::TransactionFeeEstimation(md, _) => md,
+            HttpResponseType::GetWithdrawal(md, _) => md,
             // errors
-            HttpResponseType::BadRequestJSON(ref md, _) => md,
-            HttpResponseType::BadRequest(ref md, _) => md,
-            HttpResponseType::Unauthorized(ref md, _) => md,
-            HttpResponseType::PaymentRequired(ref md, _) => md,
-            HttpResponseType::Forbidden(ref md, _) => md,
-            HttpResponseType::NotFound(ref md, _) => md,
-            HttpResponseType::ServerError(ref md, _) => md,
-            HttpResponseType::ServiceUnavailable(ref md, _) => md,
-            HttpResponseType::Error(ref md, _, _) => md,
-            HttpResponseType::BlockProposalValid { ref metadata, .. } => metadata,
-            HttpResponseType::BlockProposalInvalid { ref metadata, .. } => metadata,
+            HttpResponseType::BadRequestJSON(md, _) => md,
+            HttpResponseType::BadRequest(md, _) => md,
+            HttpResponseType::Unauthorized(md, _) => md,
+            HttpResponseType::PaymentRequired(md, _) => md,
+            HttpResponseType::Forbidden(md, _) => md,
+            HttpResponseType::NotFound(md, _) => md,
+            HttpResponseType::ServerError(md, _) => md,
+            HttpResponseType::ServiceUnavailable(md, _) => md,
+            HttpResponseType::Error(md, _, _) => md,
+            HttpResponseType::BlockProposalValid { metadata, .. } => metadata,
+            HttpResponseType::BlockProposalInvalid { metadata, .. } => metadata,
         }
     }
 

--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -7234,13 +7234,20 @@ mod test {
         let query_txt_bad = "tip=bad";
         assert_eq!(
             HttpRequestType::get_chain_tip_query(Some(query_txt_bad)),
-            TipRequest::UseLatestAnchoredTip
+            TipRequest::UseLatestUnconfirmedTip
         );
 
         // tip can be skipped
-        let query_txt_none = "tip=bad";
+        let query_txt_none = "tip=";
         assert_eq!(
             HttpRequestType::get_chain_tip_query(Some(query_txt_none)),
+            TipRequest::UseLatestUnconfirmedTip
+        );
+
+        // Return latest anchored tip
+        let query_anchored = "tip=anchored";
+        assert_eq!(
+            HttpRequestType::get_chain_tip_query(Some(query_anchored)),
             TipRequest::UseLatestAnchoredTip
         );
     }

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -1463,10 +1463,9 @@ impl ConversationHttp {
                         analysis_db.get_clarity_version(&contract_identifier)
                     })
                     .map_err(|_| {
-                        ClarityRuntimeError::from(CheckErrors::NoSuchContract(format!(
-                            "{}",
-                            &contract_identifier
-                        )))
+                        ClarityRuntimeError::from(CheckErrors::NoSuchContract(
+                            contract_identifier.to_string(),
+                        ))
                     })?;
 
                 clarity_tx.with_readonly_clarity_env(


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/blockstack/stacks-blockchain/blob/master/sip/sip-000-stacks-improvement-proposal-process.md.
-->

### Description

This PR contains the following changes:

- Change all API endpoints to use latest microblock state by default
- Add option to force anchored block use by adding `anchored` to the HTTP query
- Some minor style changes

### Applicable issues
- fixes #298

### Additional info (benefits, drawbacks, caveats)

#### Scope

This PR has a wider scope than the associated issue, as it affects all API endpoints which can accept a `tip=<string>` parameter. I'm not sure if this is desirable.

#### API Consistency

Treating microblocks as confirmed creates some inconsistency in how microblocks are reported by the API:

- Although now treated as confirmed, the latest microblock txs aren't returned by the API when `/extended/v1/tx/` is queried
- When querying the `/extended/v1/tx/{txid}` endpoint before the tx is included in an anchor block, it will have `"tx_status": "pending"` set

#### API Changes

Since API requests now default to `tip=latest`, I've added the option to use `tip=anchored` in the query string in order to not take microblocks into account when processing the request

#### Potential Race Condition

It's possible for an API call to fail when using the latest microblock tip. Relevant comment from `rpc.rs`:

```rust
    /// # Warn
    /// - There is a potential race condition. If this function is loading the latest unconfirmed
    /// tip, that tip may get invalidated by the time it is used in `maybe_read_only_clarity_tx`,
    /// which is used to load clarity state at a particular tip (which would lead to a 404 error).
    /// If this race condition occurs frequently, we can modify `maybe_read_only_clarity_tx` to
    /// re-load the unconfirmed chain tip. Refer to issue #2997.
```

See [here](https://github.com/hirosystems/stacks-subnets/blob/59bdfa600e7c016663027aabcab6e3617fe95a64/src/net/rpc.rs#L1826) for full context

### Checklist
- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
