### PR TITLE
Fix reorg handling

### DIFF
--- a/src/burnchains/mod.rs
+++ b/src/burnchains/mod.rs
@@ -476,6 +476,8 @@ pub enum Error {
     TrySyncAgain,
     UnknownBlock(BurnchainHeaderHash),
     CoordinatorClosed,
+    /// SQLite error
+    SQLiteError(rusqlite::Error),
 }
 
 impl fmt::Display for Error {
@@ -495,6 +497,7 @@ impl fmt::Display for Error {
             Error::TrySyncAgain => write!(f, "Try synchronizing again"),
             Error::UnknownBlock(block) => write!(f, "Unknown burnchain block {}", block),
             Error::CoordinatorClosed => write!(f, "ChainsCoordinator channel hung up"),
+            Error::SQLiteError(e) => write!(f, "SQLite error: {}", e),
         }
     }
 }
@@ -516,6 +519,7 @@ impl error::Error for Error {
             Error::TrySyncAgain => None,
             Error::UnknownBlock(_) => None,
             Error::CoordinatorClosed => None,
+            Error::SQLiteError(_) => None,
         }
     }
 }

--- a/src/burnchains/mod.rs
+++ b/src/burnchains/mod.rs
@@ -476,8 +476,6 @@ pub enum Error {
     TrySyncAgain,
     UnknownBlock(BurnchainHeaderHash),
     CoordinatorClosed,
-    /// SQLite error
-    SQLiteError(rusqlite::Error),
 }
 
 impl fmt::Display for Error {
@@ -497,7 +495,6 @@ impl fmt::Display for Error {
             Error::TrySyncAgain => write!(f, "Try synchronizing again"),
             Error::UnknownBlock(block) => write!(f, "Unknown burnchain block {}", block),
             Error::CoordinatorClosed => write!(f, "ChainsCoordinator channel hung up"),
-            Error::SQLiteError(e) => write!(f, "SQLite error: {}", e),
         }
     }
 }
@@ -519,7 +516,6 @@ impl error::Error for Error {
             Error::TrySyncAgain => None,
             Error::UnknownBlock(_) => None,
             Error::CoordinatorClosed => None,
-            Error::SQLiteError(_) => None,
         }
     }
 }

--- a/testnet/stacks-node/src/burnchains/db_indexer.rs
+++ b/testnet/stacks-node/src/burnchains/db_indexer.rs
@@ -608,9 +608,7 @@ impl BurnchainIndexer for DBBurnchainIndexer {
             None => {}
         }
 
-        sql_tx
-            .commit()
-            .map_err(|e| BurnchainError::SQLiteError(e))?;
+        sql_tx.commit()?;
 
         result
     }

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -135,8 +135,6 @@ struct MiningTenureInformation {
     stacks_parent_header: StacksHeaderInfo,
     /// the consensus hash of the sortition that selected the Stacks block parent
     parent_consensus_hash: ConsensusHash,
-    /// the burn block height of the sortition that selected the Stacks block parent
-    parent_block_burn_height: u64,
     /// the total amount burned in the sortition that selected the Stacks block parent
     parent_block_total_burn: u64,
     coinbase_nonce: u64,
@@ -1622,7 +1620,6 @@ impl StacksNode {
         Ok(MiningTenureInformation {
             stacks_parent_header: stacks_tip_header,
             parent_consensus_hash: mine_tip_ch.clone(),
-            parent_block_burn_height: parent_block.block_height,
             parent_block_total_burn: parent_block.total_burn,
             coinbase_nonce,
         })
@@ -1675,7 +1672,6 @@ impl StacksNode {
             MiningTenureInformation {
                 stacks_parent_header: chain_tip.metadata,
                 parent_consensus_hash: FIRST_BURNCHAIN_CONSENSUS_HASH.clone(),
-                parent_block_burn_height: 0,
                 parent_block_total_burn: 0,
                 coinbase_nonce: 0,
             }


### PR DESCRIPTION
This uses @kantai's suggestion to avoid the race condition detected when deciding if a reorg happened.